### PR TITLE
feat: My Account and My Reviews pages

### DIFF
--- a/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
@@ -6,5 +6,6 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class AccountDTO {
+    private String email;
     private boolean verifiedStudent;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/MyReviewDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/MyReviewDTO.java
@@ -1,0 +1,13 @@
+package com.curtinhonestly.backend.dto;
+
+import java.time.Instant;
+
+public record MyReviewDTO(
+        String id,
+        String unitCode,
+        String unitName,
+        int rating,
+        String reviewText,
+        String semesterTaken,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
@@ -1,6 +1,7 @@
 package com.curtinhonestly.backend.mapper;
 
 import com.curtinhonestly.backend.domain.Review;
+import com.curtinhonestly.backend.dto.MyReviewDTO;
 import com.curtinhonestly.backend.dto.ReviewDTO;
 
 import java.util.ArrayList;
@@ -26,6 +27,24 @@ public class ReviewMapper {
         }
 
         return dto;
+    }
+
+    public static MyReviewDTO mapToMyReviewDTO(Review review) {
+        String unitCode = review.getUnit() != null ? review.getUnit().getCode() : "";
+        String unitName = review.getUnit() != null ? review.getUnit().getName() : "";
+        return new MyReviewDTO(
+                review.getId(),
+                unitCode,
+                unitName,
+                review.getRating(),
+                review.getReviewText(),
+                review.getSemesterTaken(),
+                review.getCreatedAt()
+        );
+    }
+
+    public static List<MyReviewDTO> mapToMyReviewDTOs(List<Review> reviews) {
+        return reviews.stream().map(ReviewMapper::mapToMyReviewDTO).toList();
     }
 
     public static List<ReviewDTO> mapToDTOs(List<Review> reviews) {

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 public interface ReviewRepo extends JpaRepository<Review, String> {
     Optional<Review> findById(String id);
     List<Review> findByUnit_Id(String unitId);
+    List<Review> findByUser_IdOrderByCreatedAtDesc(String userId);
     long countByCreatedAtAfter(Instant since);
     List<Review> findByCreatedAtAfter(Instant since);
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
@@ -81,7 +81,35 @@ public class AuthController {
     public ResponseEntity<AccountDTO> getCurrentAccount() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         User user = userService.getUserByEmail(email);
-        return ResponseEntity.ok(new AccountDTO(user.isVerifiedStudent()));
+        return ResponseEntity.ok(new AccountDTO(user.getEmail(), user.isVerifiedStudent()));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<?> updateEmail(@RequestBody UpdateEmailRequest request) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        try {
+            User user = userService.updateEmail(email, request.newEmail(), request.password());
+            String token = jwtUtil.generateToken(
+                    user.getEmail(),
+                    user.getRoles().stream().map(Enum::name).toList()
+            );
+            return ResponseEntity.ok(new JwtResponse(token, user.isVerifiedStudent()));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.status(400).body("{\"error\": \"" + ex.getMessage() + "\"}");
+        }
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<?> deleteAccount(@RequestBody DeleteAccountRequest request) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        try {
+            userService.deleteAccount(email, request.password());
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.status(400).body("{\"error\": \"" + ex.getMessage() + "\"}");
+        }
     }
 
     @PostMapping("/verify-student")
@@ -119,5 +147,7 @@ public class AuthController {
     public record RegisterRequest(String email, String password) {}
     public record LoginRequest(String email, String password) {}
     public record VerifyStudentRequest(String studentEmail, String password) {}
+    public record UpdateEmailRequest(String newEmail, String password) {}
+    public record DeleteAccountRequest(String password) {}
     public record JwtResponse(String token, boolean verifiedStudent) {}
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
@@ -1,5 +1,6 @@
 package com.curtinhonestly.backend.resource;
 
+import com.curtinhonestly.backend.dto.MyReviewDTO;
 import com.curtinhonestly.backend.dto.ReviewDTO;
 import com.curtinhonestly.backend.mapper.ReviewMapper;
 import com.curtinhonestly.backend.domain.Review;
@@ -21,6 +22,12 @@ import java.util.List;
 public class ReviewResource {
 
     private final ReviewService reviewService;
+
+    @GetMapping("/me")
+    @PreAuthorize(SecurityConstants.HAS_ROLE_USER)
+    public ResponseEntity<List<MyReviewDTO>> getMyReviews() {
+        return ResponseEntity.ok(ReviewMapper.mapToMyReviewDTOs(reviewService.getReviewsForCurrentUser()));
+    }
 
     @GetMapping
     public ResponseEntity<List<ReviewDTO>> getAllReviews() {

--- a/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
 
                         // Admin namespace and sensitive listings
                         .requestMatchers("/admin/**").hasAuthority(UserRole.ROLE_ADMIN.name())
+                        .requestMatchers(HttpMethod.GET, "/reviews/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/reviews", "/reviews/**").hasAuthority(UserRole.ROLE_ADMIN.name())
                         .requestMatchers(HttpMethod.GET, "/users", "/users/**").hasAuthority(UserRole.ROLE_ADMIN.name())
 

--- a/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
@@ -97,4 +97,11 @@ public class ReviewService {
     public List<Review> getAllReviews() {
         return reviewRepo.findAll();
     }
+
+    public List<Review> getReviewsForCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepo.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found: " + email));
+        return reviewRepo.findByUser_IdOrderByCreatedAtDesc(user.getId());
+    }
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/service/UserService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/UserService.java
@@ -71,4 +71,40 @@ public class UserService {
         log.info("User {} verified as student with email {}", savedUser.getId(), studentEmail);
         return savedUser;
     }
+
+    public User updateEmail(String currentEmail, String newEmail, String password) {
+        User user = getUserByEmail(currentEmail);
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("Invalid password.");
+        }
+
+        if (newEmail == null || !newEmail.contains("@") || !newEmail.contains(".")) {
+            throw new IllegalArgumentException("Please provide a valid email address.");
+        }
+
+        String normalizedEmail = newEmail.trim().toLowerCase();
+        userRepo.findByEmail(normalizedEmail)
+                .filter(existing -> !existing.getId().equals(user.getId()))
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("That email is already in use.");
+                });
+
+        user.setEmail(normalizedEmail);
+        user.setVerifiedStudent(StudentEmailValidator.isStudentEmail(normalizedEmail));
+        User savedUser = userRepo.saveAndFlush(user);
+        log.info("User {} updated email", savedUser.getId());
+        return savedUser;
+    }
+
+    public void deleteAccount(String email, String password) {
+        User user = getUserByEmail(email);
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new IllegalArgumentException("Invalid password.");
+        }
+
+        userRepo.delete(user);
+        log.info("User {} deleted their account", user.getId());
+    }
 }

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -30,7 +30,8 @@
         <a routerLink="/register" class="register-link" (click)="closeMobileNav()">Register</a>
       </ng-container>
       <ng-container *ngIf="authService.isLoggedIn()">
-        <a routerLink="/account" (click)="closeMobileNav()">Account</a>
+        <a routerLink="/my-reviews" (click)="closeMobileNav()">My Reviews</a>
+        <a routerLink="/account" (click)="closeMobileNav()">My Account</a>
         <a href="javascript:void(0)" (click)="logout()">Logout</a>
       </ng-container>
     </nav>

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,20 +4,15 @@ import { UnitDetailComponent } from './components/unit-detail/unit-detail.compon
 import { LoginComponent } from './components/login/login.component';
 import { RegisterComponent } from './components/register/register.component';
 import { AccountComponent } from './components/account/account.component';
+import { MyReviewsComponent } from './components/my-reviews/my-reviews.component';
+import { authGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
-  // The home page showing all units
   { path: '', component: UnitListComponent },
-  
-  // Auth pages
   { path: 'login', component: LoginComponent },
   { path: 'register', component: RegisterComponent },
-  { path: 'account', component: AccountComponent },
-  
-  // The detail page for a specific unit (e.g., /units/COMP1000)
-  // Beginners: the ':code' part is a placeholder for the actual unit code
+  { path: 'account', component: AccountComponent, canActivate: [authGuard] },
+  { path: 'my-reviews', component: MyReviewsComponent, canActivate: [authGuard] },
   { path: 'units/:code', component: UnitDetailComponent },
-  
-  // Catch-all route to redirect back home if the URL is wrong
   { path: '**', redirectTo: '' }
 ];

--- a/frontend/src/app/components/account/account.component.css
+++ b/frontend/src/app/components/account/account.component.css
@@ -1,18 +1,140 @@
 @import '../login/login.component.css';
 
-.info-text {
+.page-container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
+
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-header .subtitle {
+  text-align: left;
+  margin-bottom: 0;
+  color: var(--text-secondary);
+}
+
+.account-section {
+  background: var(--card-background);
+  border: 1px solid var(--border-color);
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.account-section h2 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+}
+
+.section-hint {
   color: var(--text-secondary);
   font-size: 0.95rem;
-  margin-bottom: 24px;
+  margin: 0 0 16px;
   line-height: 1.5;
+}
+
+.detail-list {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 12px 16px;
+  margin: 0;
+}
+
+.detail-list dt {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.detail-list dd {
+  margin: 0;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.status-badge.verified {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.status-badge.unverified {
+  background: #f7f7f7;
+  color: var(--text-secondary);
+}
+
+.stacked-form .form-group {
+  margin-bottom: 16px;
+}
+
+.btn-primary {
+  width: auto;
+  min-width: 160px;
+}
+
+.btn-danger {
+  background: #fff5f5;
+  color: #c53030;
+  border: 1px solid #feb2b2;
+  padding: 12px 20px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #fed7d7;
+}
+
+.btn-danger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.danger-zone {
+  border-color: #feb2b2;
 }
 
 .success-box {
   background-color: #eff6ff;
   color: #1d4ed8;
   padding: 12px;
-  border-radius: var(--radius-none);
   border-left: 4px solid #2563eb;
   margin-bottom: 20px;
   font-size: 0.9rem;
+}
+
+.page-footer {
+  margin-top: 8px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.page-footer a {
+  color: var(--primary-color);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.page-footer a:hover {
+  text-decoration: underline;
+}
+
+.sep {
+  margin: 0 8px;
+}
+
+@media (max-width: 640px) {
+  .detail-list {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+
+  .detail-list dt {
+    margin-top: 8px;
+  }
 }

--- a/frontend/src/app/components/account/account.component.html
+++ b/frontend/src/app/components/account/account.component.html
@@ -1,20 +1,59 @@
-<div class="auth-container">
-  <div class="auth-card">
-    <h2>Your Account</h2>
-    <p class="subtitle">Reviews are posted anonymously. Your email is never shown on reviews.</p>
+<div class="page-container">
+  <div class="page-header">
+    <h1 class="handbook-title">My Account</h1>
+    <p class="subtitle">Manage your email, verification status, and account settings. Reviews are always posted anonymously.</p>
+  </div>
 
-    <div *ngIf="authService.verifiedStudent()" class="success-box">
-      You are a verified Curtin student. Your reviews show a verified badge.
-    </div>
+  @if (errorMessage()) {
+    <div class="error-box">{{ errorMessage() }}</div>
+  }
+  @if (successMessage()) {
+    <div class="success-box">{{ successMessage() }}</div>
+  }
 
-    <div *ngIf="!authService.verifiedStudent()">
-      <p class="info-text">
-        Verify with your Curtin student email to display a verified badge on your reviews.
+  <section class="account-section card">
+    <h2>Account details</h2>
+    <dl class="detail-list">
+      <dt>Email</dt>
+      <dd>{{ authService.email() || 'Loading…' }}</dd>
+      <dt>Status</dt>
+      <dd>
+        @if (authService.verifiedStudent()) {
+          <span class="status-badge verified">Verified Curtin student</span>
+        } @else {
+          <span class="status-badge unverified">Not verified</span>
+        }
+      </dd>
+    </dl>
+  </section>
+
+  <section class="account-section card">
+    <h2>Update email</h2>
+    <p class="section-hint">Change the email you use to sign in. You will need your current password.</p>
+    <form (ngSubmit)="onUpdateEmail()" class="stacked-form">
+      <div class="form-group">
+        <label for="newEmail">New email</label>
+        <input type="email" id="newEmail" name="newEmail" [(ngModel)]="newEmail" required />
+      </div>
+      <div class="form-group">
+        <label for="emailPassword">Current password</label>
+        <input type="password" id="emailPassword" name="emailPassword" [(ngModel)]="emailPassword" required />
+      </div>
+      <button type="submit" class="btn btn-primary" [disabled]="isLoading() || !newEmail || !emailPassword">
+        {{ isLoading() ? 'Saving…' : 'Update email' }}
+      </button>
+    </form>
+  </section>
+
+  @if (!authService.verifiedStudent()) {
+    <section class="account-section card">
+      <h2>Verify as Curtin student</h2>
+      <p class="section-hint">
+        Link your @student.curtin.edu.au email to show a verified badge on your reviews.
       </p>
-
-      <form (ngSubmit)="onVerify()" #verifyForm="ngForm">
+      <form (ngSubmit)="onVerify()" class="stacked-form">
         <div class="form-group">
-          <label for="studentEmail">Curtin Student Email</label>
+          <label for="studentEmail">Curtin student email</label>
           <input
             type="email"
             id="studentEmail"
@@ -22,36 +61,36 @@
             [(ngModel)]="studentEmail"
             required
             placeholder="your.name@student.curtin.edu.au"
-          >
+          />
         </div>
-
         <div class="form-group">
-          <label for="password">Current Password</label>
-          <input
-            type="password"
-            id="password"
-            name="password"
-            [(ngModel)]="password"
-            required
-          >
+          <label for="verifyPassword">Current password</label>
+          <input type="password" id="verifyPassword" name="verifyPassword" [(ngModel)]="verifyPassword" required />
         </div>
-
-        <div *ngIf="errorMessage()" class="error-box">
-          {{ errorMessage() }}
-        </div>
-
-        <div *ngIf="successMessage()" class="success-box">
-          {{ successMessage() }}
-        </div>
-
-        <button type="submit" [disabled]="!verifyForm.valid || isLoading()" class="btn btn-primary">
-          {{ isLoading() ? 'Verifying...' : 'Verify as student' }}
+        <button type="submit" class="btn btn-primary" [disabled]="isLoading() || !studentEmail || !verifyPassword">
+          {{ isLoading() ? 'Verifying…' : 'Verify as student' }}
         </button>
       </form>
-    </div>
+    </section>
+  }
 
-    <div class="auth-footer">
-      <a routerLink="/">Back to home</a>
-    </div>
+  <section class="account-section card danger-zone">
+    <h2>Delete account</h2>
+    <p class="section-hint">Permanently remove your account and all reviews you have posted.</p>
+    <form (ngSubmit)="onDeleteAccount()" class="stacked-form">
+      <div class="form-group">
+        <label for="deletePassword">Confirm with your password</label>
+        <input type="password" id="deletePassword" name="deletePassword" [(ngModel)]="deletePassword" required />
+      </div>
+      <button type="submit" class="btn btn-danger" [disabled]="isLoading() || !deletePassword">
+        {{ isLoading() ? 'Deleting…' : 'Delete my account' }}
+      </button>
+    </form>
+  </section>
+
+  <div class="page-footer">
+    <a routerLink="/my-reviews">My Reviews</a>
+    <span class="sep">·</span>
+    <a routerLink="/">Back to home</a>
   </div>
 </div>

--- a/frontend/src/app/components/account/account.component.ts
+++ b/frontend/src/app/components/account/account.component.ts
@@ -15,8 +15,12 @@ export class AccountComponent implements OnInit {
   protected authService = inject(AuthService);
   private router = inject(Router);
 
+  newEmail = '';
+  emailPassword = '';
   studentEmail = '';
-  password = '';
+  verifyPassword = '';
+  deletePassword = '';
+
   errorMessage = signal<string | null>(null);
   successMessage = signal<string | null>(null);
   isLoading = signal(false);
@@ -32,30 +36,76 @@ export class AccountComponent implements OnInit {
     });
   }
 
+  onUpdateEmail() {
+    this.clearMessages();
+    this.isLoading.set(true);
+
+    this.authService.updateEmail({
+      newEmail: this.newEmail,
+      password: this.emailPassword
+    }).subscribe({
+      next: () => {
+        this.isLoading.set(false);
+        this.successMessage.set('Email updated successfully.');
+        this.newEmail = '';
+        this.emailPassword = '';
+      },
+      error: (err) => {
+        this.isLoading.set(false);
+        this.errorMessage.set(err.error?.error || 'Failed to update email.');
+      }
+    });
+  }
+
   onVerify() {
     if (!this.studentEmail.endsWith('@student.curtin.edu.au')) {
       this.errorMessage.set('Please enter a valid @student.curtin.edu.au email.');
       return;
     }
 
+    this.clearMessages();
     this.isLoading.set(true);
-    this.errorMessage.set(null);
-    this.successMessage.set(null);
 
     this.authService.verifyStudent({
       studentEmail: this.studentEmail,
-      password: this.password
+      password: this.verifyPassword
     }).subscribe({
       next: () => {
         this.isLoading.set(false);
         this.successMessage.set('Your account is now verified as a Curtin student.');
         this.studentEmail = '';
-        this.password = '';
+        this.verifyPassword = '';
       },
       error: (err) => {
         this.isLoading.set(false);
         this.errorMessage.set(err.error?.error || 'Verification failed. Please try again.');
       }
     });
+  }
+
+  onDeleteAccount() {
+    if (!confirm('Delete your account permanently? All your reviews will be removed. This cannot be undone.')) {
+      return;
+    }
+
+    this.clearMessages();
+    this.isLoading.set(true);
+
+    this.authService.deleteAccount(this.deletePassword).subscribe({
+      next: () => {
+        this.isLoading.set(false);
+        this.authService.logout();
+        this.router.navigate(['/']);
+      },
+      error: (err) => {
+        this.isLoading.set(false);
+        this.errorMessage.set(err.error?.error || 'Failed to delete account.');
+      }
+    });
+  }
+
+  private clearMessages() {
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
   }
 }

--- a/frontend/src/app/components/my-reviews/my-reviews.component.css
+++ b/frontend/src/app/components/my-reviews/my-reviews.component.css
@@ -1,0 +1,227 @@
+.page-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px 0 40px;
+}
+
+.page-header {
+  margin-bottom: 24px;
+}
+
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  margin: 8px 0 0;
+}
+
+.card {
+  background: var(--card-background);
+  border: 1px solid var(--border-color);
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.error-box {
+  background: #fff5f5;
+  color: #c53030;
+  padding: 12px;
+  border-left: 4px solid #c53030;
+  margin-bottom: 16px;
+}
+
+.success-box {
+  background: #eff6ff;
+  color: #1d4ed8;
+  padding: 12px;
+  border-left: 4px solid #2563eb;
+  margin-bottom: 16px;
+}
+
+.add-flow-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.add-flow h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.section-hint,
+.empty-hint,
+.loading-text {
+  color: var(--text-secondary);
+}
+
+.search-input {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  font-size: 1rem;
+  margin-bottom: 12px;
+  box-sizing: border-box;
+}
+
+.unit-pick-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.unit-pick-item {
+  width: 100%;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  padding: 12px 14px;
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  background: white;
+  text-align: left;
+  cursor: pointer;
+}
+
+.unit-pick-item:hover {
+  background: #fafafa;
+}
+
+.unit-pick-item:last-child {
+  border-bottom: none;
+}
+
+.unit-code {
+  font-weight: 700;
+  min-width: 90px;
+}
+
+.unit-name {
+  color: var(--text-secondary);
+}
+
+.selected-unit {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.review-list {
+  display: grid;
+  gap: 16px;
+}
+
+.review-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.review-card h3 {
+  margin: 4px 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.unit-link {
+  color: var(--primary-color);
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.unit-link:hover {
+  text-decoration: underline;
+}
+
+.rating {
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.review-excerpt {
+  margin: 0 0 12px;
+  line-height: 1.5;
+}
+
+.review-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.review-actions {
+  display: flex;
+  gap: 16px;
+}
+
+.btn-text {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--primary-color);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-text.danger {
+  color: #c53030;
+}
+
+.btn-text:hover {
+  text-decoration: underline;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 32px 20px;
+}
+
+.empty-state p {
+  margin: 0 0 16px;
+  color: var(--text-secondary);
+}
+
+.page-footer {
+  margin-top: 8px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.page-footer a {
+  color: var(--primary-color);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.page-footer a:hover {
+  text-decoration: underline;
+}
+
+.sep {
+  margin: 0 8px;
+}
+
+@media (max-width: 640px) {
+  .header-row .btn-primary {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/components/my-reviews/my-reviews.component.html
+++ b/frontend/src/app/components/my-reviews/my-reviews.component.html
@@ -1,0 +1,107 @@
+<div class="page-container">
+  <div class="page-header">
+    <div class="header-row">
+      <div>
+        <h1 class="handbook-title">My Reviews</h1>
+        <p class="subtitle">All reviews you have posted. They appear anonymously on unit pages.</p>
+      </div>
+      @if (!showAddFlow()) {
+        <button type="button" class="btn btn-primary" (click)="startAddReview()">Add new review</button>
+      }
+    </div>
+  </div>
+
+  @if (errorMessage()) {
+    <div class="error-box">{{ errorMessage() }}</div>
+  }
+  @if (successMessage()) {
+    <div class="success-box">{{ successMessage() }}</div>
+  }
+
+  @if (showAddFlow()) {
+    <section class="add-flow card">
+      <div class="add-flow-header">
+        <h2>Add a review</h2>
+        <button type="button" class="btn-text" (click)="cancelAddReview()">Cancel</button>
+      </div>
+
+      @if (!selectedUnitCode()) {
+        <p class="section-hint">Search for a unit, then select one to write your review.</p>
+        <input
+          type="text"
+          class="search-input"
+          [(ngModel)]="searchQuery"
+          (ngModelChange)="onSearchChange()"
+          placeholder="Search by unit code or name…"
+        />
+
+        @if (searchResults$ | async; as units) {
+          @if (units.length === 0) {
+            <p class="empty-hint">No units found. Try a different search.</p>
+          } @else {
+            <ul class="unit-pick-list">
+              @for (unit of units; track unit.code) {
+                <li>
+                  <button type="button" class="unit-pick-item" (click)="selectUnit(unit)">
+                    <span class="unit-code">{{ unit.code }}</span>
+                    <span class="unit-name">{{ unit.name }}</span>
+                  </button>
+                </li>
+              }
+            </ul>
+          }
+        }
+      } @else {
+        <div class="selected-unit">
+          <strong>{{ selectedUnitCode() }}</strong> — {{ selectedUnitName() }}
+          <button type="button" class="btn-text" (click)="selectedUnitCode.set(null)">Change unit</button>
+        </div>
+        <app-add-review
+          [unitCode]="selectedUnitCode()!"
+          (reviewAdded)="onReviewAdded()"
+          (cancel)="cancelAddReview()"
+        />
+      }
+    </section>
+  }
+
+  @if (isLoading()) {
+    <p class="loading-text">Loading your reviews…</p>
+  } @else if (reviews().length === 0) {
+    <div class="empty-state card">
+      <p>You have not posted any reviews yet.</p>
+      <button type="button" class="btn btn-primary" (click)="startAddReview()">Write your first review</button>
+    </div>
+  } @else {
+    <div class="review-list">
+      @for (review of reviews(); track review.id) {
+        <article class="review-card card">
+          <div class="review-card-header">
+            <div>
+              <a class="unit-link" (click)="viewUnit(review.unitCode)">{{ review.unitCode }}</a>
+              <h3>{{ review.unitName }}</h3>
+            </div>
+            <div class="rating">{{ review.rating }}/5</div>
+          </div>
+          <p class="review-excerpt">{{ review.reviewText }}</p>
+          <div class="review-meta">
+            <span>{{ review.semesterTaken }}</span>
+            @if (review.createdAt) {
+              <span>{{ review.createdAt | date: 'mediumDate' }}</span>
+            }
+          </div>
+          <div class="review-actions">
+            <button type="button" class="btn-text" (click)="viewUnit(review.unitCode)">View unit</button>
+            <button type="button" class="btn-text danger" (click)="deleteReview(review)">Delete</button>
+          </div>
+        </article>
+      }
+    </div>
+  }
+
+  <div class="page-footer">
+    <a routerLink="/account">My Account</a>
+    <span class="sep">·</span>
+    <a routerLink="/">Back to home</a>
+  </div>
+</div>

--- a/frontend/src/app/components/my-reviews/my-reviews.component.ts
+++ b/frontend/src/app/components/my-reviews/my-reviews.component.ts
@@ -1,0 +1,111 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { BehaviorSubject, debounceTime, distinctUntilChanged, map, Observable, switchMap } from 'rxjs';
+import { ReviewService } from '../../services/review.service';
+import { UnitService } from '../../services/unit.service';
+import { MyReview, UnitSummary } from '../../models/unit.model';
+import { AddReviewComponent } from '../add-review/add-review.component';
+
+@Component({
+  selector: 'app-my-reviews',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, AddReviewComponent],
+  templateUrl: './my-reviews.component.html',
+  styleUrl: './my-reviews.component.css'
+})
+export class MyReviewsComponent implements OnInit {
+  private reviewService = inject(ReviewService);
+  private unitService = inject(UnitService);
+  private router = inject(Router);
+
+  reviews = signal<MyReview[]>([]);
+  isLoading = signal(true);
+  errorMessage = signal<string | null>(null);
+  successMessage = signal<string | null>(null);
+
+  showAddFlow = signal(false);
+  selectedUnitCode = signal<string | null>(null);
+  selectedUnitName = signal<string | null>(null);
+
+  searchQuery = '';
+  private searchSubject = new BehaviorSubject<string>('');
+  searchResults$: Observable<UnitSummary[]> | undefined;
+
+  ngOnInit() {
+    this.loadReviews();
+
+    this.searchResults$ = this.searchSubject.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap(query =>
+        this.unitService.getUnits(0, 20, query || undefined, [], undefined, 'code')
+      ),
+      map(page => page.content)
+    );
+  }
+
+  loadReviews() {
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+
+    this.reviewService.getMyReviews().subscribe({
+      next: (reviews) => {
+        this.reviews.set(reviews);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.errorMessage.set('Failed to load your reviews.');
+        this.isLoading.set(false);
+      }
+    });
+  }
+
+  startAddReview() {
+    this.showAddFlow.set(true);
+    this.selectedUnitCode.set(null);
+    this.selectedUnitName.set(null);
+    this.searchQuery = '';
+    this.searchSubject.next('');
+  }
+
+  cancelAddReview() {
+    this.showAddFlow.set(false);
+    this.selectedUnitCode.set(null);
+    this.selectedUnitName.set(null);
+  }
+
+  onSearchChange() {
+    this.searchSubject.next(this.searchQuery);
+  }
+
+  selectUnit(unit: UnitSummary) {
+    this.selectedUnitCode.set(unit.code);
+    this.selectedUnitName.set(unit.name);
+  }
+
+  onReviewAdded() {
+    this.successMessage.set('Review submitted successfully.');
+    this.cancelAddReview();
+    this.loadReviews();
+  }
+
+  deleteReview(review: MyReview) {
+    if (!confirm(`Delete your review for ${review.unitCode}?`)) {
+      return;
+    }
+
+    this.reviewService.deleteReview(review.id).subscribe({
+      next: () => {
+        this.successMessage.set('Review deleted.');
+        this.loadReviews();
+      },
+      error: () => this.errorMessage.set('Failed to delete review.')
+    });
+  }
+
+  viewUnit(code: string) {
+    this.router.navigate(['/units', code]);
+  }
+}

--- a/frontend/src/app/guards/auth.guard.ts
+++ b/frontend/src/app/guards/auth.guard.ts
@@ -1,0 +1,12 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isLoggedIn()) {
+    return true;
+  }
+  return router.createUrlTree(['/login']);
+};

--- a/frontend/src/app/models/unit.model.ts
+++ b/frontend/src/app/models/unit.model.ts
@@ -46,6 +46,16 @@ export interface Review {
   reviewerVerified: boolean;
 }
 
+export interface MyReview {
+  id: string;
+  unitCode: string;
+  unitName: string;
+  rating: number;
+  reviewText: string;
+  semesterTaken: string;
+  createdAt: string;
+}
+
 export interface TuitionPattern {
   type: string;
   duration: string;

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -18,12 +18,18 @@ export interface VerifyStudentRequest {
   password: string;
 }
 
+export interface UpdateEmailRequest {
+  newEmail: string;
+  password: string;
+}
+
 export interface JwtResponse {
   token: string;
   verifiedStudent: boolean;
 }
 
 export interface AccountStatus {
+  email: string;
   verifiedStudent: boolean;
 }
 
@@ -36,30 +42,45 @@ export class AuthService {
 
   isLoggedIn = signal<boolean>(this.hasStoredToken());
   verifiedStudent = signal<boolean>(this.getStoredVerifiedStudent());
+  email = signal<string | null>(this.getStoredEmail());
 
   login(request: LoginRequest): Observable<JwtResponse> {
     return this.http.post<JwtResponse>(`${this.apiUrl}/login`, request).pipe(
-      tap(response => this.persistSession(response.token, response.verifiedStudent))
+      tap(response => this.persistSession(response.token, response.verifiedStudent, request.email))
     );
   }
 
   register(request: RegisterRequest): Observable<JwtResponse> {
     return this.http.post<JwtResponse>(`${this.apiUrl}/register`, request).pipe(
-      tap(response => this.persistSession(response.token, response.verifiedStudent))
+      tap(response => this.persistSession(response.token, response.verifiedStudent, request.email))
     );
   }
 
   verifyStudent(request: VerifyStudentRequest): Observable<JwtResponse> {
     return this.http.post<JwtResponse>(`${this.apiUrl}/verify-student`, request).pipe(
-      tap(response => this.persistSession(response.token, response.verifiedStudent))
+      tap(response => {
+        this.persistSession(response.token, response.verifiedStudent, request.studentEmail);
+      })
     );
+  }
+
+  updateEmail(request: UpdateEmailRequest): Observable<JwtResponse> {
+    return this.http.patch<JwtResponse>(`${this.apiUrl}/me`, request).pipe(
+      tap(response => this.persistSession(response.token, response.verifiedStudent, request.newEmail))
+    );
+  }
+
+  deleteAccount(password: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/me`, { body: { password } });
   }
 
   refreshAccountStatus(): Observable<AccountStatus> {
     return this.http.get<AccountStatus>(`${this.apiUrl}/me`).pipe(
       tap(status => {
         localStorage.setItem('verified_student', String(status.verifiedStudent));
+        localStorage.setItem('user_email', status.email);
         this.verifiedStudent.set(status.verifiedStudent);
+        this.email.set(status.email);
       })
     );
   }
@@ -67,15 +88,19 @@ export class AuthService {
   logout() {
     localStorage.removeItem('auth_token');
     localStorage.removeItem('verified_student');
+    localStorage.removeItem('user_email');
     this.isLoggedIn.set(false);
     this.verifiedStudent.set(false);
+    this.email.set(null);
   }
 
-  private persistSession(token: string, verifiedStudent: boolean) {
+  private persistSession(token: string, verifiedStudent: boolean, email: string) {
     localStorage.setItem('auth_token', token);
     localStorage.setItem('verified_student', String(verifiedStudent));
+    localStorage.setItem('user_email', email);
     this.isLoggedIn.set(true);
     this.verifiedStudent.set(verifiedStudent);
+    this.email.set(email);
   }
 
   private hasStoredToken(): boolean {
@@ -90,5 +115,12 @@ export class AuthService {
       return false;
     }
     return localStorage.getItem('verified_student') === 'true';
+  }
+
+  private getStoredEmail(): string | null {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+    return localStorage.getItem('user_email');
   }
 }

--- a/frontend/src/app/services/review.service.ts
+++ b/frontend/src/app/services/review.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { Review } from '../models/unit.model';
 import { environment } from '../../environments/environment';
+import { MyReview } from '../models/unit.model';
 
 @Injectable({
   providedIn: 'root'
@@ -11,8 +11,12 @@ export class ReviewService {
   private http = inject(HttpClient);
   private apiUrl = `${environment.apiUrl}/reviews`;
 
-  createReview(review: any): Observable<Review> {
-    return this.http.post<Review>(this.apiUrl, review);
+  getMyReviews(): Observable<MyReview[]> {
+    return this.http.get<MyReview[]>(`${this.apiUrl}/me`);
+  }
+
+  createReview(review: unknown): Observable<unknown> {
+    return this.http.post(this.apiUrl, review);
   }
 
   deleteReview(id: string): Observable<void> {


### PR DESCRIPTION
## Summary
- Expand `GET /auth/me` to return email; add `PATCH /auth/me` and `DELETE /auth/me` for self-service account management
- Add `GET /reviews/me` for the current user''s reviews
- Expand My Account with email update, student verification, and account deletion
- Add My Reviews page with review list, delete, and inline unit search + add-review flow
- Add auth guard and nav links for logged-in users

## Depends on
- #31 (`feat/anonymous-verified-users` → `dev`)
- #34 (`feat/admin-panel`)

## Test plan
- [ ] Logged-in user can view and update email on My Account
- [ ] Student verification flow still works from My Account
- [ ] My Reviews lists only the current user''s reviews
- [ ] User can delete their own review from My Reviews
- [ ] User can search units and add a review inline from My Reviews
- [ ] Account deletion removes the user and signs them out
- [ ] Auth-guarded routes redirect unauthenticated users to login