### PR TITLE
hotfix(seo): use curtinhonestly.com as canonical SITE_URL

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
+++ b/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
@@ -39,6 +39,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         env:
           API_URL: ${{ secrets.API_URL }}
+          SITE_URL: https://curtinhonestly.com
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_SAND_081CC7100 }}
           action: upload

--- a/AZURE_DEPLOYMENT.md
+++ b/AZURE_DEPLOYMENT.md
@@ -234,6 +234,7 @@ Or use GitHub Environment secrets and branch conditions (dev branch → dev API 
 |---|---|---|
 | dev | `API_URL` | `https://curtinhonestly-be-dev....azurecontainerapps.io` |
 | prod | `API_URL` | `https://curtinhonestly-be-prod....azurecontainerapps.io` |
+| prod | `SITE_URL` | `https://curtinhonestly.com` (canonical URL for sitemap, OG tags, JSON-LD) |
 
 Build command becomes:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A website where university students in Australia can leave honest reviews for th
 
 | Environment | Frontend | Backend |
 |---|---|---|
-| **Production** | https://icy-sand-081cc7100.7.azurestaticapps.net | `https://be-curtinhonestly-prod.happyplant-9f34dec7.australiaeast.azurecontainerapps.io` |
+| **Production** | https://curtinhonestly.com | `https://be-curtinhonestly-prod.happyplant-9f34dec7.australiaeast.azurecontainerapps.io` |
 | **Dev** | https://nice-pebble-059fa6b00.7.azurestaticapps.net | `https://be-curtinhonestly-dev.happyplant-9f34dec7.australiaeast.azurecontainerapps.io` |
 
 ---
@@ -36,7 +36,7 @@ A website where university students in Australia can leave honest reviews for th
                  ┌─────────────────────────────┐
    Users ──────► │  Azure Static Web Apps (FE)  │   Azure "Free" subscription
                  │  dev: nice-pebble            │
-                 │  prod: icy-sand              │
+                 │  prod: curtinhonestly.com    │
                  └──────────────┬──────────────┘
                                 │ HTTPS (API_URL)
                                 ▼

--- a/frontend/scripts/seo-build-config.js
+++ b/frontend/scripts/seo-build-config.js
@@ -1,0 +1,80 @@
+/**
+ * Shared SEO build settings for set-env and pre-build scripts.
+ * Prod only: prerender, sitemap, and indexable meta tags.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const envPath = path.resolve(__dirname, '../../.env');
+
+function readEnvFile() {
+  const values = {};
+  if (!fs.existsSync(envPath)) {
+    return values;
+  }
+
+  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
+    const [key, ...valueParts] = line.split('=');
+    if (key && valueParts.length > 0) {
+      values[key.trim()] = valueParts.join('=').trim().replace(/"/g, '');
+    }
+  }
+
+  return values;
+}
+
+function isDevApiUrl(apiUrl) {
+  const normalized = apiUrl.toLowerCase();
+  return (
+    normalized.includes('localhost') ||
+    normalized.includes('127.0.0.1') ||
+    normalized.includes('be-curtinhonestly-dev') ||
+    /[^a-z]dev[^a-z]/.test(normalized) ||
+    normalized.includes('-dev.')
+  );
+}
+
+function defaultSiteUrl(apiUrl) {
+  const normalized = apiUrl.toLowerCase();
+  if (normalized.includes('localhost') || normalized.includes('127.0.0.1')) {
+    return 'http://localhost:4200';
+  }
+  if (isDevApiUrl(apiUrl)) {
+    return 'https://nice-pebble-059fa6b00.7.azurestaticapps.net';
+  }
+  return 'https://curtinhonestly.com';
+}
+
+function resolveSeoEnabled(apiUrl) {
+  const explicit = process.env.SEO_ENABLED;
+  if (explicit !== undefined && explicit !== '') {
+    return explicit === 'true' || explicit === '1';
+  }
+  return !isDevApiUrl(apiUrl);
+}
+
+function resolveSeoBuildConfig() {
+  const fileEnv = readEnvFile();
+  const apiUrl = process.env.API_URL || fileEnv.API_URL || 'http://localhost:8080';
+  const production =
+    process.env.NODE_ENV === 'production' ||
+    process.env.VERCEL_ENV === 'production' ||
+    fileEnv.NODE_ENV === 'production';
+
+  let siteUrl = process.env.SITE_URL || fileEnv.SITE_URL;
+  if (!siteUrl) {
+    siteUrl = defaultSiteUrl(apiUrl);
+  }
+
+  return {
+    apiUrl,
+    siteUrl: siteUrl.replace(/\/$/, ''),
+    production,
+    seoEnabled: resolveSeoEnabled(apiUrl),
+  };
+}
+
+module.exports = {
+  resolveSeoBuildConfig,
+  isDevApiUrl,
+};


### PR DESCRIPTION
## Summary
- Set prod `SITE_URL` to `https://curtinhonestly.com` in the prod SWA workflow so sitemap, robots.txt, and prerendered meta use the custom domain.
- Update `seo-build-config.js` prod default from the Azure `icy-sand` hostname to `curtinhonestly.com`.
- Refresh README and deployment docs with the production frontend URL.

## Why
Google Search Console rejected the sitemap when URLs used the default Azure SWA hostname instead of the verified custom domain.

## Promote to prod
After merging to `dev`, open a release/hotfix PR `dev` → `main` and re-run **Azure Static Web Apps CI/CD (Prod)**.

## Test plan
- [ ] Merge to `dev`
- [ ] Promote `dev` → `main`
- [ ] Confirm prod build log shows `SITE_URL: https://curtinhonestly.com`
- [ ] `https://curtinhonestly.com/sitemap.xml` lists `curtinhonestly.com` URLs
- [ ] Submit `sitemap.xml` in GSC under the `https://curtinhonestly.com` property
