### PR TITLE
fix(ci): prod SWA deploy on push to main only

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
+++ b/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
@@ -4,36 +4,20 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     environment: prod
     permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false
-      - name: Install OIDC Client from Core Package
-        run: npm install @actions/core@1.6.0 @actions/http-client
-      - name: Get Id Token
-        uses: actions/github-script@v6
-        id: idtoken
-        with:
-          script: |
-            const coredemo = require('@actions/core')
-            return await coredemo.getIDToken()
-          result-encoding: string
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -47,35 +31,3 @@ jobs:
           api_location: ''
           output_location: dist/frontend/browser
           app_build_command: npm run build
-          github_id_token: ${{ steps.idtoken.outputs.result }}
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install OIDC Client from Core Package
-        run: npm install @actions/core@1.6.0 @actions/http-client
-      - name: Get Id Token
-        uses: actions/github-script@v6
-        id: idtoken
-        with:
-          script: |
-            const coredemo = require('@actions/core')
-            return await coredemo.getIDToken()
-          result-encoding: string
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_SAND_081CC7100 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: close
-          app_location: frontend
-          api_location: ''
-          output_location: dist/frontend/browser
-          github_id_token: ${{ steps.idtoken.outputs.result }}


### PR DESCRIPTION
## Summary
- Prod SWA workflow now runs only on `push` to `main` and `workflow_dispatch` (no PR preview deploys).
- Removes unused OIDC / `github_id_token` steps that triggered action warnings.

## Why
PR preview deploys to the **prod** SWA fail with `No matching static site build found`. Production should deploy when code lands on `main`, not during open PRs.

`SITE_URL: https://curtinhonestly.com` is unchanged — that only affects sitemap/canonical URLs in the build. The app still deploys to the icy-sand SWA; `curtinhonestly.com` is the custom domain alias in Azure.

## Test plan
- [ ] Merge to `dev`, then promote to `main`
- [ ] Manual workflow dispatch on `main` succeeds
- [ ] Open PR to `main` no longer runs failing prod SWA job
