### PR TITLE
feat: Campaign promo codes, referral links, and draw entry tokens

### DIFF
--- a/admin-frontend/src/app/app.html
+++ b/admin-frontend/src/app/app.html
@@ -10,6 +10,7 @@
         <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Overview</a>
         <a routerLink="/analytics" routerLinkActive="active">Analytics</a>
         <a routerLink="/operations" routerLinkActive="active">Operations</a>
+        <a routerLink="/campaigns" routerLinkActive="active">Campaigns</a>
       </nav>
 
       <div class="user-actions">

--- a/admin-frontend/src/app/app.routes.ts
+++ b/admin-frontend/src/app/app.routes.ts
@@ -4,11 +4,13 @@ import { LoginComponent } from './pages/login/login.component';
 import { OverviewComponent } from './pages/overview/overview.component';
 import { AnalyticsComponent } from './pages/analytics/analytics.component';
 import { OperationsComponent } from './pages/operations/operations.component';
+import { CampaignsComponent } from './pages/campaigns/campaigns.component';
 
 export const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: '', component: OverviewComponent, canActivate: [adminGuard] },
   { path: 'analytics', component: AnalyticsComponent, canActivate: [adminGuard] },
   { path: 'operations', component: OperationsComponent, canActivate: [adminGuard] },
+  { path: 'campaigns', component: CampaignsComponent, canActivate: [adminGuard] },
   { path: '**', redirectTo: '' }
 ];

--- a/admin-frontend/src/app/models/admin.model.ts
+++ b/admin-frontend/src/app/models/admin.model.ts
@@ -58,6 +58,8 @@ export interface CampaignAdmin {
   maxRedemptions: number | null;
   minReviewLength: number;
   maxEntriesPerUser: number;
+  requireVerifiedStudent: boolean;
+  requiredReviewCount: number;
   signupCount: number;
   entryCount: number;
   createdAt: string;

--- a/admin-frontend/src/app/models/admin.model.ts
+++ b/admin-frontend/src/app/models/admin.model.ts
@@ -45,3 +45,28 @@ export interface PagedReviews {
   totalPages: number;
   number: number;
 }
+
+export interface CampaignAdmin {
+  id: string;
+  slug: string;
+  code: string;
+  name: string;
+  prizeDescription: string | null;
+  startsAt: string;
+  endsAt: string;
+  active: boolean;
+  maxRedemptions: number | null;
+  minReviewLength: number;
+  maxEntriesPerUser: number;
+  signupCount: number;
+  entryCount: number;
+  createdAt: string;
+}
+
+export interface CampaignEntryAdmin {
+  id: string;
+  entryToken: string;
+  userEmail: string;
+  unitCode: string;
+  createdAt: string;
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.css
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.css
@@ -64,3 +64,10 @@ code {
   font-family: monospace;
   font-size: 0.85rem;
 }
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.css
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.css
@@ -1,0 +1,66 @@
+.section {
+  margin-bottom: 16px;
+}
+
+h2 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.form-grid input {
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.subtle {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.section-header h2 {
+  margin: 0;
+}
+
+.success-banner {
+  background: #ecfdf3;
+  border: 1px solid #abefc6;
+  color: var(--success-color);
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+code {
+  font-family: monospace;
+  font-size: 0.85rem;
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.html
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.html
@@ -1,0 +1,113 @@
+<h1 class="page-title">Campaigns</h1>
+<p class="page-subtitle">Create outreach campaigns with referral links, promo codes, and draw entry tracking.</p>
+
+@if (errorMessage()) {
+  <div class="error-banner">{{ errorMessage() }}</div>
+}
+@if (successMessage()) {
+  <div class="success-banner">{{ successMessage() }}</div>
+}
+
+<section class="card section">
+  <h2>Create campaign</h2>
+  <div class="form-grid">
+    <input type="text" placeholder="Slug (ref param), e.g. discord-computing-jul26" [(ngModel)]="slug" name="slug" />
+    <input type="text" placeholder="Promo code, e.g. CURTIN-JUL26" [(ngModel)]="code" name="code" />
+    <input type="text" placeholder="Campaign name" [(ngModel)]="name" name="name" />
+    <input type="text" placeholder="Prize description" [(ngModel)]="prizeDescription" name="prizeDescription" />
+    <label>
+      Starts
+      <input type="datetime-local" [(ngModel)]="startsAt" name="startsAt" />
+    </label>
+    <label>
+      Ends
+      <input type="datetime-local" [(ngModel)]="endsAt" name="endsAt" />
+    </label>
+    <input type="number" placeholder="Max signups (optional)" [(ngModel)]="maxRedemptions" name="maxRedemptions" />
+    <input type="number" placeholder="Min review length" [(ngModel)]="minReviewLength" name="minReviewLength" />
+    <input type="number" placeholder="Max entries per user" [(ngModel)]="maxEntriesPerUser" name="maxEntriesPerUser" />
+  </div>
+  <button type="button" class="btn btn-primary" (click)="createCampaign()">Create campaign</button>
+</section>
+
+<section class="card section">
+  <h2>Campaigns</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Slug / Code</th>
+        <th>Window</th>
+        <th>Signups</th>
+        <th>Entries</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (campaign of campaigns(); track campaign.id) {
+        <tr>
+          <td>
+            <strong>{{ campaign.name }}</strong>
+            @if (campaign.prizeDescription) {
+              <div class="subtle">{{ campaign.prizeDescription }}</div>
+            }
+          </td>
+          <td>
+            <div><code>{{ campaign.slug }}</code></div>
+            <div><code>{{ campaign.code }}</code></div>
+          </td>
+          <td>
+            {{ campaign.startsAt | date: 'mediumDate' }} –
+            {{ campaign.endsAt | date: 'mediumDate' }}
+          </td>
+          <td>{{ campaign.signupCount }}</td>
+          <td>{{ campaign.entryCount }}</td>
+          <td>
+            @if (campaign.active) {
+              <span class="badge badge-active">Active</span>
+            } @else {
+              <span class="badge">Inactive</span>
+            }
+          </td>
+          <td class="actions">
+            <button type="button" class="btn" (click)="copyLink(campaign)">Copy link</button>
+            <button type="button" class="btn" (click)="viewEntries(campaign)">Entries</button>
+            <button type="button" class="btn" (click)="toggleActive(campaign)">
+              {{ campaign.active ? 'Deactivate' : 'Activate' }}
+            </button>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</section>
+
+@if (selectedEntries().length) {
+  <section class="card section">
+    <div class="section-header">
+      <h2>Draw entries</h2>
+      <button type="button" class="btn btn-primary" (click)="exportEntriesCsv()">Export CSV</button>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Entry token</th>
+          <th>User</th>
+          <th>Unit</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (entry of selectedEntries(); track entry.id) {
+          <tr>
+            <td><code>{{ entry.entryToken }}</code></td>
+            <td>{{ entry.userEmail }}</td>
+            <td>{{ entry.unitCode }}</td>
+            <td>{{ entry.createdAt | date: 'short' }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </section>
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.html
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.html
@@ -25,7 +25,12 @@
     </label>
     <input type="number" placeholder="Max signups (optional)" [(ngModel)]="maxRedemptions" name="maxRedemptions" />
     <input type="number" placeholder="Min review length" [(ngModel)]="minReviewLength" name="minReviewLength" />
-    <input type="number" placeholder="Max entries per user" [(ngModel)]="maxEntriesPerUser" name="maxEntriesPerUser" />
+    <input type="number" placeholder="Required reviews for entry" [(ngModel)]="requiredReviewCount" name="requiredReviewCount" />
+    <input type="number" placeholder="Max draw entries per user" [(ngModel)]="maxEntriesPerUser" name="maxEntriesPerUser" />
+    <label class="checkbox">
+      <input type="checkbox" [(ngModel)]="requireVerifiedStudent" name="requireVerifiedStudent" />
+      Require verified student
+    </label>
   </div>
   <button type="button" class="btn btn-primary" (click)="createCampaign()">Create campaign</button>
 </section>
@@ -56,6 +61,11 @@
           <td>
             <div><code>{{ campaign.slug }}</code></div>
             <div><code>{{ campaign.code }}</code></div>
+            <div class="subtle">
+              {{ campaign.requiredReviewCount }} review(s) ·
+              {{ campaign.requireVerifiedStudent ? 'verified only' : 'any account' }} ·
+              min {{ campaign.minReviewLength }} chars
+            </div>
           </td>
           <td>
             {{ campaign.startsAt | date: 'mediumDate' }} –

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
@@ -1,0 +1,137 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AdminService } from '../../services/admin.service';
+import { CampaignAdmin, CampaignEntryAdmin } from '../../models/admin.model';
+
+@Component({
+  selector: 'app-campaigns',
+  imports: [FormsModule, DatePipe],
+  templateUrl: './campaigns.component.html',
+  styleUrl: './campaigns.component.css'
+})
+export class CampaignsComponent implements OnInit {
+  private adminService = inject(AdminService);
+
+  campaigns = signal<CampaignAdmin[]>([]);
+  selectedEntries = signal<CampaignEntryAdmin[]>([]);
+  selectedCampaignId = signal<string | null>(null);
+  errorMessage = signal<string | null>(null);
+  successMessage = signal<string | null>(null);
+
+  slug = '';
+  code = '';
+  name = '';
+  prizeDescription = '';
+  startsAt = '';
+  endsAt = '';
+  maxRedemptions: number | null = null;
+  minReviewLength = 50;
+  maxEntriesPerUser = 5;
+
+  ngOnInit(): void {
+    this.refreshCampaigns();
+    this.setDefaultDates();
+  }
+
+  refreshCampaigns(): void {
+    this.adminService.listCampaigns().subscribe({
+      next: (data) => this.campaigns.set(data),
+      error: () => this.errorMessage.set('Failed to load campaigns.')
+    });
+  }
+
+  createCampaign(): void {
+    this.clearMessages();
+
+    this.adminService.createCampaign({
+      slug: this.slug,
+      code: this.code,
+      name: this.name,
+      prizeDescription: this.prizeDescription,
+      startsAt: new Date(this.startsAt).toISOString(),
+      endsAt: new Date(this.endsAt).toISOString(),
+      maxRedemptions: this.maxRedemptions,
+      minReviewLength: this.minReviewLength,
+      maxEntriesPerUser: this.maxEntriesPerUser
+    }).subscribe({
+      next: () => {
+        this.successMessage.set('Campaign created.');
+        this.slug = '';
+        this.code = '';
+        this.name = '';
+        this.prizeDescription = '';
+        this.maxRedemptions = null;
+        this.setDefaultDates();
+        this.refreshCampaigns();
+      },
+      error: (err) => this.errorMessage.set(err.error?.error || 'Failed to create campaign.')
+    });
+  }
+
+  toggleActive(campaign: CampaignAdmin): void {
+    this.clearMessages();
+    this.adminService.setCampaignActive(campaign.id, !campaign.active).subscribe({
+      next: () => {
+        this.successMessage.set(campaign.active ? 'Campaign deactivated.' : 'Campaign activated.');
+        this.refreshCampaigns();
+      },
+      error: () => this.errorMessage.set('Failed to update campaign status.')
+    });
+  }
+
+  viewEntries(campaign: CampaignAdmin): void {
+    this.clearMessages();
+    this.selectedCampaignId.set(campaign.id);
+    this.adminService.listCampaignEntries(campaign.id).subscribe({
+      next: (entries) => this.selectedEntries.set(entries),
+      error: () => this.errorMessage.set('Failed to load campaign entries.')
+    });
+  }
+
+  registrationLink(campaign: CampaignAdmin): string {
+    const origin = typeof window !== 'undefined' ? window.location.origin.replace(':4201', ':4200') : 'https://curtinhonestly.com';
+    return `${origin}/register?ref=${encodeURIComponent(campaign.slug)}&code=${encodeURIComponent(campaign.code)}`;
+  }
+
+  copyLink(campaign: CampaignAdmin): void {
+    navigator.clipboard.writeText(this.registrationLink(campaign)).then(() => {
+      this.successMessage.set('Registration link copied.');
+    }).catch(() => this.errorMessage.set('Could not copy link.'));
+  }
+
+  exportEntriesCsv(): void {
+    const entries = this.selectedEntries();
+    if (!entries.length) {
+      return;
+    }
+
+    const header = 'entryToken,userEmail,unitCode,createdAt';
+    const rows = entries.map(entry =>
+      [entry.entryToken, entry.userEmail, entry.unitCode, entry.createdAt]
+        .map(value => `"${String(value).replace(/"/g, '""')}"`)
+        .join(',')
+    );
+    const csv = [header, ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `campaign-entries-${this.selectedCampaignId()}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  private setDefaultDates(): void {
+    const now = new Date();
+    const end = new Date(now);
+    end.setDate(end.getDate() + 21);
+    this.startsAt = now.toISOString().slice(0, 16);
+    this.endsAt = end.toISOString().slice(0, 16);
+  }
+
+  private clearMessages(): void {
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+  }
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
@@ -27,7 +27,9 @@ export class CampaignsComponent implements OnInit {
   endsAt = '';
   maxRedemptions: number | null = null;
   minReviewLength = 50;
-  maxEntriesPerUser = 5;
+  maxEntriesPerUser = 1;
+  requireVerifiedStudent = true;
+  requiredReviewCount = 1;
 
   ngOnInit(): void {
     this.refreshCampaigns();
@@ -53,7 +55,9 @@ export class CampaignsComponent implements OnInit {
       endsAt: new Date(this.endsAt).toISOString(),
       maxRedemptions: this.maxRedemptions,
       minReviewLength: this.minReviewLength,
-      maxEntriesPerUser: this.maxEntriesPerUser
+      maxEntriesPerUser: this.maxEntriesPerUser,
+      requireVerifiedStudent: this.requireVerifiedStudent,
+      requiredReviewCount: this.requiredReviewCount
     }).subscribe({
       next: () => {
         this.successMessage.set('Campaign created.');

--- a/admin-frontend/src/app/services/admin.service.ts
+++ b/admin-frontend/src/app/services/admin.service.ts
@@ -71,6 +71,8 @@ export class AdminService {
     maxRedemptions: number | null;
     minReviewLength: number;
     maxEntriesPerUser: number;
+    requireVerifiedStudent: boolean;
+    requiredReviewCount: number;
   }): Observable<CampaignAdmin> {
     return this.http.post<CampaignAdmin>(`${this.apiUrl}/campaigns`, payload);
   }

--- a/admin-frontend/src/app/services/admin.service.ts
+++ b/admin-frontend/src/app/services/admin.service.ts
@@ -6,6 +6,8 @@ import {
   AdminAnalytics,
   AdminOverview,
   AdminReview,
+  CampaignAdmin,
+  CampaignEntryAdmin,
   PagedReviews,
   UserAdmin
 } from '../models/admin.model';
@@ -53,5 +55,31 @@ export class AdminService {
 
   deleteReview(id: string): Observable<void> {
     return this.http.delete<void>(`${this.apiUrl}/reviews/${id}`);
+  }
+
+  listCampaigns(): Observable<CampaignAdmin[]> {
+    return this.http.get<CampaignAdmin[]>(`${this.apiUrl}/campaigns`);
+  }
+
+  createCampaign(payload: {
+    slug: string;
+    code: string;
+    name: string;
+    prizeDescription: string;
+    startsAt: string;
+    endsAt: string;
+    maxRedemptions: number | null;
+    minReviewLength: number;
+    maxEntriesPerUser: number;
+  }): Observable<CampaignAdmin> {
+    return this.http.post<CampaignAdmin>(`${this.apiUrl}/campaigns`, payload);
+  }
+
+  setCampaignActive(id: string, active: boolean): Observable<CampaignAdmin> {
+    return this.http.patch<CampaignAdmin>(`${this.apiUrl}/campaigns/${id}/active`, { active });
+  }
+
+  listCampaignEntries(id: string): Observable<CampaignEntryAdmin[]> {
+    return this.http.get<CampaignEntryAdmin[]>(`${this.apiUrl}/campaigns/${id}/entries`);
   }
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
@@ -52,6 +52,12 @@ public class Campaign {
     @Column(nullable = false)
     private int maxEntriesPerUser = 5;
 
+    @Column(nullable = false)
+    private boolean requireVerifiedStudent = true;
+
+    @Column(nullable = false)
+    private int requiredReviewCount = 1;
+
     @Column(nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
@@ -1,0 +1,57 @@
+package com.curtinhonestly.backend.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "campaigns")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class Campaign {
+
+    @Id
+    @UuidGenerator
+    private String id;
+
+    @Column(unique = true, nullable = false)
+    private String slug;
+
+    @Column(unique = true, nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(length = 500)
+    private String prizeDescription;
+
+    @Column(nullable = false)
+    private Instant startsAt;
+
+    @Column(nullable = false)
+    private Instant endsAt;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    private Integer maxRedemptions;
+
+    @Column(nullable = false)
+    private int minReviewLength = 50;
+
+    @Column(nullable = false)
+    private int maxEntriesPerUser = 5;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/CampaignEntry.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/CampaignEntry.java
@@ -1,0 +1,47 @@
+package com.curtinhonestly.backend.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "campaign_entries")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class CampaignEntry {
+
+    @Id
+    @UuidGenerator
+    private String id;
+
+    @Column(unique = true, nullable = false, length = 16)
+    private String entryToken;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "campaign_id", nullable = false)
+    private Campaign campaign;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "review_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Review review;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
@@ -15,7 +15,10 @@ import java.time.Instant;
 @Entity
 
 // Map to the "reviews" table
-@Table(name = "reviews")
+@Table(
+        name = "reviews",
+        uniqueConstraints = @UniqueConstraint(name = "uk_reviews_user_unit", columnNames = {"user_id", "unit_id"})
+)
 
 // Lombok getters/setters
 @Getter

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/User.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/User.java
@@ -61,6 +61,13 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Review> reviews;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "campaign_id")
+    private Campaign campaign;
+
+    @Column(length = 100)
+    private String registeredViaRef;
+
 }
 
 

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
@@ -14,5 +14,6 @@ public class AccountDTO {
     private String campaignName;
     private String campaignPrizeDescription;
     private Instant campaignEndsAt;
+    private CampaignProgressDTO campaignProgress;
     private List<CampaignEntrySummaryDTO> campaignEntries;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
@@ -3,9 +3,16 @@ package com.curtinhonestly.backend.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.Instant;
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 public class AccountDTO {
     private String email;
     private boolean verifiedStudent;
+    private String campaignName;
+    private String campaignPrizeDescription;
+    private Instant campaignEndsAt;
+    private List<CampaignEntrySummaryDTO> campaignEntries;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
@@ -1,0 +1,25 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignAdminDTO {
+    private String id;
+    private String slug;
+    private String code;
+    private String name;
+    private String prizeDescription;
+    private Instant startsAt;
+    private Instant endsAt;
+    private boolean active;
+    private Integer maxRedemptions;
+    private int minReviewLength;
+    private int maxEntriesPerUser;
+    private long signupCount;
+    private long entryCount;
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
@@ -19,6 +19,8 @@ public class CampaignAdminDTO {
     private Integer maxRedemptions;
     private int minReviewLength;
     private int maxEntriesPerUser;
+    private boolean requireVerifiedStudent;
+    private int requiredReviewCount;
     private long signupCount;
     private long entryCount;
     private Instant createdAt;

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntryAdminDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntryAdminDTO.java
@@ -1,0 +1,16 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignEntryAdminDTO {
+    private String id;
+    private String entryToken;
+    private String userEmail;
+    private String unitCode;
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntrySummaryDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntrySummaryDTO.java
@@ -1,0 +1,15 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignEntrySummaryDTO {
+    private String entryToken;
+    private String campaignName;
+    private String unitCode;
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignProgressDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignProgressDTO.java
@@ -1,0 +1,14 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CampaignProgressDTO {
+    private int qualifyingReviews;
+    private int requiredReviews;
+    private int entriesEarned;
+    private int maxEntries;
+    private boolean requireVerifiedStudent;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignValidationDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignValidationDTO.java
@@ -1,0 +1,16 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignValidationDTO {
+    private boolean valid;
+    private String message;
+    private String campaignName;
+    private String prizeDescription;
+    private Instant endsAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
@@ -1,0 +1,14 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CreateReviewResponseDTO {
+    private ReviewDTO review;
+    private String campaignEntryToken;
+    private String campaignName;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
@@ -11,4 +11,5 @@ public class CreateReviewResponseDTO {
     private ReviewDTO review;
     private String campaignEntryToken;
     private String campaignName;
+    private CampaignProgressDTO campaignProgress;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/MyReviewDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/MyReviewDTO.java
@@ -7,7 +7,12 @@ public record MyReviewDTO(
         String unitCode,
         String unitName,
         int rating,
+        Integer finalGrade,
         String reviewText,
         String semesterTaken,
+        String professor,
+        int workload,
+        boolean hasExam,
+        boolean wouldTakeAgain,
         Instant createdAt
 ) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
@@ -37,8 +37,13 @@ public class ReviewMapper {
                 unitCode,
                 unitName,
                 review.getRating(),
+                review.getFinalGrade(),
                 review.getReviewText(),
                 review.getSemesterTaken(),
+                review.getProfessor(),
+                review.getWorkload(),
+                review.isHasExam(),
+                review.isWouldTakeAgain(),
                 review.getCreatedAt()
         );
     }

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignEntryRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignEntryRepo.java
@@ -1,0 +1,37 @@
+package com.curtinhonestly.backend.repo;
+
+import com.curtinhonestly.backend.domain.CampaignEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CampaignEntryRepo extends JpaRepository<CampaignEntry, String> {
+    long countByCampaign_IdAndUser_Id(String campaignId, String userId);
+    long countByCampaign_Id(String campaignId);
+
+    @Query("""
+            SELECT e FROM CampaignEntry e
+            JOIN FETCH e.review r
+            JOIN FETCH r.unit
+            JOIN FETCH e.campaign
+            WHERE e.user.id = :userId
+            ORDER BY e.createdAt DESC
+            """)
+    List<CampaignEntry> findByUser_IdOrderByCreatedAtDesc(@Param("userId") String userId);
+
+    @Query("""
+            SELECT e FROM CampaignEntry e
+            JOIN FETCH e.review r
+            JOIN FETCH r.unit
+            JOIN FETCH e.user
+            WHERE e.campaign.id = :campaignId
+            ORDER BY e.createdAt DESC
+            """)
+    List<CampaignEntry> findByCampaign_IdOrderByCreatedAtDesc(@Param("campaignId") String campaignId);
+
+    Optional<CampaignEntry> findByEntryTokenIgnoreCase(String entryToken);
+    boolean existsByReview_Id(String reviewId);
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignRepo.java
@@ -1,0 +1,13 @@
+package com.curtinhonestly.backend.repo;
+
+import com.curtinhonestly.backend.domain.Campaign;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CampaignRepo extends JpaRepository<Campaign, String> {
+    Optional<Campaign> findBySlugIgnoreCase(String slug);
+    Optional<Campaign> findByCodeIgnoreCase(String code);
+    List<Campaign> findAllByOrderByCreatedAtDesc();
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
@@ -13,6 +13,8 @@ public interface ReviewRepo extends JpaRepository<Review, String> {
     Optional<Review> findById(String id);
     List<Review> findByUnit_Id(String unitId);
     List<Review> findByUser_IdOrderByCreatedAtDesc(String userId);
+    Optional<Review> findByUser_IdAndUnit_Id(String userId, String unitId);
+    boolean existsByUser_IdAndUnit_Id(String userId, String unitId);
     long countByCreatedAtAfter(Instant since);
     List<Review> findByCreatedAtAfter(Instant since);
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/UserRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/UserRepo.java
@@ -11,4 +11,5 @@ public interface UserRepo extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
     long countByCreatedAtAfter(Instant since);
     List<User> findByCreatedAtAfter(Instant since);
+    long countByCampaign_Id(String campaignId);
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
@@ -3,6 +3,7 @@ package com.curtinhonestly.backend.resource;
 import com.curtinhonestly.backend.dto.*;
 import com.curtinhonestly.backend.security.SecurityConstants;
 import com.curtinhonestly.backend.service.AdminService;
+import com.curtinhonestly.backend.service.CampaignService;
 import com.curtinhonestly.backend.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.List;
 
 @RestController
@@ -20,6 +22,7 @@ public class AdminResource {
 
     private final AdminService adminService;
     private final ReviewService reviewService;
+    private final CampaignService campaignService;
 
     @GetMapping("/stats/overview")
     public ResponseEntity<AdminOverviewDTO> getOverview() {
@@ -75,5 +78,56 @@ public class AdminResource {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/campaigns")
+    public ResponseEntity<List<CampaignAdminDTO>> listCampaigns() {
+        return ResponseEntity.ok(campaignService.listCampaigns());
+    }
+
+    @PostMapping("/campaigns")
+    public ResponseEntity<?> createCampaign(@RequestBody CreateCampaignRequest request) {
+        try {
+            return ResponseEntity.ok(campaignService.createCampaign(
+                    request.slug(),
+                    request.code(),
+                    request.name(),
+                    request.prizeDescription(),
+                    request.startsAt(),
+                    request.endsAt(),
+                    request.maxRedemptions(),
+                    request.minReviewLength(),
+                    request.maxEntriesPerUser()
+            ));
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.badRequest()
+                    .body("{\"error\": \"" + ex.getMessage() + "\"}");
+        }
+    }
+
+    @PatchMapping("/campaigns/{id}/active")
+    public ResponseEntity<CampaignAdminDTO> setCampaignActive(
+            @PathVariable String id,
+            @RequestBody SetCampaignActiveRequest request) {
+        return ResponseEntity.ok(campaignService.setCampaignActive(id, request.active()));
+    }
+
+    @GetMapping("/campaigns/{id}/entries")
+    public ResponseEntity<List<CampaignEntryAdminDTO>> listCampaignEntries(@PathVariable String id) {
+        return ResponseEntity.ok(campaignService.listEntriesForCampaign(id));
+    }
+
     public record CreateUserRequest(String email, String password, boolean admin) {}
+
+    public record CreateCampaignRequest(
+            String slug,
+            String code,
+            String name,
+            String prizeDescription,
+            Instant startsAt,
+            Instant endsAt,
+            Integer maxRedemptions,
+            int minReviewLength,
+            int maxEntriesPerUser
+    ) {}
+
+    public record SetCampaignActiveRequest(boolean active) {}
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
@@ -95,7 +95,9 @@ public class AdminResource {
                     request.endsAt(),
                     request.maxRedemptions(),
                     request.minReviewLength(),
-                    request.maxEntriesPerUser()
+                    request.maxEntriesPerUser(),
+                    request.requireVerifiedStudent(),
+                    request.requiredReviewCount()
             ));
         } catch (IllegalArgumentException ex) {
             return ResponseEntity.badRequest()
@@ -126,7 +128,9 @@ public class AdminResource {
             Instant endsAt,
             Integer maxRedemptions,
             int minReviewLength,
-            int maxEntriesPerUser
+            int maxEntriesPerUser,
+            boolean requireVerifiedStudent,
+            int requiredReviewCount
     ) {}
 
     public record SetCampaignActiveRequest(boolean active) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
@@ -119,6 +119,7 @@ public class AuthController {
                 campaign != null ? campaign.getName() : null,
                 campaign != null ? campaign.getPrizeDescription() : null,
                 campaign != null ? campaign.getEndsAt() : null,
+                campaignService.getCampaignProgress(user),
                 entries
         ));
     }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
@@ -1,8 +1,11 @@
 package com.curtinhonestly.backend.resource;
 
+import com.curtinhonestly.backend.domain.Campaign;
 import com.curtinhonestly.backend.domain.User;
 import com.curtinhonestly.backend.dto.AccountDTO;
+import com.curtinhonestly.backend.dto.CampaignEntrySummaryDTO;
 import com.curtinhonestly.backend.security.JwtUtil;
+import com.curtinhonestly.backend.service.CampaignService;
 import com.curtinhonestly.backend.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +17,9 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -23,6 +29,7 @@ public class AuthController {
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
     private final UserService userService;
+    private final CampaignService campaignService;
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
@@ -35,7 +42,29 @@ public class AuthController {
         }
 
         try {
-            User user = userService.createUser(request.email(), request.password());
+            Optional<Campaign> campaignOpt = hasCampaignAttribution(request)
+                    ? campaignService.resolveCampaignForRegistration(request.ref(), request.promoCode())
+                    : Optional.empty();
+
+            if (hasCampaignAttribution(request) && campaignOpt.isEmpty()) {
+                return ResponseEntity.status(400)
+                        .body("{\"error\": \"Campaign not found. Check your referral link or promo code.\"}");
+            }
+
+            if (campaignOpt.isPresent()) {
+                var validation = campaignService.validateCampaign(request.ref(), request.promoCode());
+                if (!validation.isValid()) {
+                    return ResponseEntity.status(400)
+                            .body("{\"error\": \"" + validation.getMessage() + "\"}");
+                }
+            }
+
+            User user = userService.createUser(
+                    request.email(),
+                    request.password(),
+                    campaignOpt.orElse(null),
+                    request.ref()
+            );
             String token = jwtUtil.generateToken(
                     user.getEmail(),
                     user.getRoles().stream().map(Enum::name).toList()
@@ -81,7 +110,17 @@ public class AuthController {
     public ResponseEntity<AccountDTO> getCurrentAccount() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         User user = userService.getUserByEmail(email);
-        return ResponseEntity.ok(new AccountDTO(user.getEmail(), user.isVerifiedStudent()));
+        var campaign = user.getCampaign();
+        List<CampaignEntrySummaryDTO> entries = campaignService.getEntriesForUser(user);
+
+        return ResponseEntity.ok(new AccountDTO(
+                user.getEmail(),
+                user.isVerifiedStudent(),
+                campaign != null ? campaign.getName() : null,
+                campaign != null ? campaign.getPrizeDescription() : null,
+                campaign != null ? campaign.getEndsAt() : null,
+                entries
+        ));
     }
 
     @PatchMapping("/me")
@@ -144,7 +183,12 @@ public class AuthController {
         return email != null && email.contains("@") && email.contains(".");
     }
 
-    public record RegisterRequest(String email, String password) {}
+    private boolean hasCampaignAttribution(RegisterRequest request) {
+        return (request.ref() != null && !request.ref().isBlank())
+                || (request.promoCode() != null && !request.promoCode().isBlank());
+    }
+
+    public record RegisterRequest(String email, String password, String ref, String promoCode) {}
     public record LoginRequest(String email, String password) {}
     public record VerifyStudentRequest(String studentEmail, String password) {}
     public record UpdateEmailRequest(String newEmail, String password) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/CampaignResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/CampaignResource.java
@@ -1,0 +1,25 @@
+package com.curtinhonestly.backend.resource;
+
+import com.curtinhonestly.backend.dto.CampaignValidationDTO;
+import com.curtinhonestly.backend.service.CampaignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/campaigns")
+@RequiredArgsConstructor
+public class CampaignResource {
+
+    private final CampaignService campaignService;
+
+    @GetMapping("/validate")
+    public ResponseEntity<CampaignValidationDTO> validateCampaign(
+            @RequestParam(required = false) String ref,
+            @RequestParam(required = false) String code) {
+        return ResponseEntity.ok(campaignService.validateCampaign(ref, code));
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
@@ -1,7 +1,7 @@
 package com.curtinhonestly.backend.resource;
 
-import com.curtinhonestly.backend.dto.MyReviewDTO;
 import com.curtinhonestly.backend.dto.CreateReviewResponseDTO;
+import com.curtinhonestly.backend.dto.MyReviewDTO;
 import com.curtinhonestly.backend.dto.ReviewDTO;
 import com.curtinhonestly.backend.mapper.ReviewMapper;
 import com.curtinhonestly.backend.domain.Review;
@@ -30,6 +30,14 @@ public class ReviewResource {
         return ResponseEntity.ok(ReviewMapper.mapToMyReviewDTOs(reviewService.getReviewsForCurrentUser()));
     }
 
+    @GetMapping("/me/unit/{unitCode}")
+    @PreAuthorize(SecurityConstants.HAS_ROLE_USER)
+    public ResponseEntity<MyReviewDTO> getMyReviewForUnit(@PathVariable String unitCode) {
+        return reviewService.getReviewForCurrentUserAndUnit(unitCode)
+                .map(review -> ResponseEntity.ok(ReviewMapper.mapToMyReviewDTO(review)))
+                .orElse(ResponseEntity.noContent().build());
+    }
+
     @GetMapping
     public ResponseEntity<List<ReviewDTO>> getAllReviews() {
         return ResponseEntity.ok(ReviewMapper.mapToDTOs(reviewService.getAllReviews()));
@@ -40,19 +48,8 @@ public class ReviewResource {
     public ResponseEntity<?> createReview(@RequestBody Review review) {
         try {
             ReviewService.ReviewCreationResult result = reviewService.createReviewWithCampaignEntry(review);
-            Review savedReview = result.review();
-            ReviewDTO reviewDto = ReviewMapper.mapToDTO(savedReview);
-
-            String entryToken = null;
-            String campaignName = null;
-            if (result.campaignEntry().isPresent()) {
-                var entry = result.campaignEntry().get();
-                entryToken = entry.getEntryToken();
-                campaignName = entry.getCampaign().getName();
-            }
-
-            CreateReviewResponseDTO response = new CreateReviewResponseDTO(reviewDto, entryToken, campaignName);
-            return ResponseEntity.created(URI.create("/reviews/" + savedReview.getId())).body(response);
+            return ResponseEntity.created(URI.create("/reviews/" + result.review().getId()))
+                    .body(toCreateReviewResponse(result));
         } catch (IllegalArgumentException e) {
             log.warn("Review validation failed: {}", e.getMessage());
             return ResponseEntity.badRequest()
@@ -65,10 +62,48 @@ public class ReviewResource {
         }
     }
 
+    @PatchMapping("/{id}")
+    @PreAuthorize(SecurityConstants.IS_ADMIN_OR_OWNER)
+    public ResponseEntity<?> updateReview(@PathVariable String id, @RequestBody Review review) {
+        try {
+            ReviewService.ReviewCreationResult result = reviewService.updateReviewWithCampaignEntry(id, review);
+            return ResponseEntity.ok(toCreateReviewResponse(result));
+        } catch (IllegalArgumentException e) {
+            log.warn("Review update failed: {}", e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body("{\"error\": \"" + e.getMessage() + "\"}");
+        } catch (Exception e) {
+            log.error("Error updating review: {}", e.getMessage(), e);
+            String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            return ResponseEntity.internalServerError()
+                    .body("{\"error\": \"Failed to update review: " + message + "\"}");
+        }
+    }
+
     @DeleteMapping("/{id}")
     @PreAuthorize(SecurityConstants.IS_ADMIN_OR_OWNER)
     public ResponseEntity<?> deleteReview(@PathVariable String id) {
         reviewService.deleteReviewById(id);
         return ResponseEntity.noContent().build();
+    }
+
+    private CreateReviewResponseDTO toCreateReviewResponse(ReviewService.ReviewCreationResult result) {
+        Review savedReview = result.review();
+        ReviewDTO reviewDto = ReviewMapper.mapToDTO(savedReview);
+
+        String entryToken = null;
+        String campaignName = null;
+        if (result.campaignEntry().isPresent()) {
+            var entry = result.campaignEntry().get();
+            entryToken = entry.getEntryToken();
+            campaignName = entry.getCampaign().getName();
+        }
+
+        return new CreateReviewResponseDTO(
+                reviewDto,
+                entryToken,
+                campaignName,
+                result.campaignProgress()
+        );
     }
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
@@ -1,6 +1,7 @@
 package com.curtinhonestly.backend.resource;
 
 import com.curtinhonestly.backend.dto.MyReviewDTO;
+import com.curtinhonestly.backend.dto.CreateReviewResponseDTO;
 import com.curtinhonestly.backend.dto.ReviewDTO;
 import com.curtinhonestly.backend.mapper.ReviewMapper;
 import com.curtinhonestly.backend.domain.Review;
@@ -38,9 +39,24 @@ public class ReviewResource {
     @PreAuthorize(SecurityConstants.HAS_ROLE_USER)
     public ResponseEntity<?> createReview(@RequestBody Review review) {
         try {
-            Review savedReview = reviewService.createReview(review);
-            return ResponseEntity.created(URI.create("/reviews/" + savedReview.getId()))
-                    .body(ReviewMapper.mapToDTO(savedReview));
+            ReviewService.ReviewCreationResult result = reviewService.createReviewWithCampaignEntry(review);
+            Review savedReview = result.review();
+            ReviewDTO reviewDto = ReviewMapper.mapToDTO(savedReview);
+
+            String entryToken = null;
+            String campaignName = null;
+            if (result.campaignEntry().isPresent()) {
+                var entry = result.campaignEntry().get();
+                entryToken = entry.getEntryToken();
+                campaignName = entry.getCampaign().getName();
+            }
+
+            CreateReviewResponseDTO response = new CreateReviewResponseDTO(reviewDto, entryToken, campaignName);
+            return ResponseEntity.created(URI.create("/reviews/" + savedReview.getId())).body(response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Review validation failed: {}", e.getMessage());
+            return ResponseEntity.badRequest()
+                    .body("{\"error\": \"" + e.getMessage() + "\"}");
         } catch (Exception e) {
             log.error("Error creating review: {}", e.getMessage(), e);
             String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();

--- a/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
 
                         // Admin namespace and sensitive listings
                         .requestMatchers("/admin/**").hasAuthority(UserRole.ROLE_ADMIN.name())
-                        .requestMatchers(HttpMethod.GET, "/reviews/me").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/reviews/me", "/reviews/me/**").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/reviews/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/reviews", "/reviews/**").hasAuthority(UserRole.ROLE_ADMIN.name())
                         .requestMatchers(HttpMethod.GET, "/users", "/users/**").hasAuthority(UserRole.ROLE_ADMIN.name())
 

--- a/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         // Public read endpoints for the student app
                         .requestMatchers(HttpMethod.GET, "/units", "/units/**").permitAll()
                         .requestMatchers("/auth/register", "/auth/login").permitAll()
+                        .requestMatchers("/campaigns/validate").permitAll()
                         .requestMatchers("/auth/me", "/auth/verify-student").authenticated()
                         .requestMatchers("/error").permitAll()
 

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -7,9 +7,11 @@ import com.curtinhonestly.backend.domain.User;
 import com.curtinhonestly.backend.dto.CampaignAdminDTO;
 import com.curtinhonestly.backend.dto.CampaignEntryAdminDTO;
 import com.curtinhonestly.backend.dto.CampaignEntrySummaryDTO;
+import com.curtinhonestly.backend.dto.CampaignProgressDTO;
 import com.curtinhonestly.backend.dto.CampaignValidationDTO;
 import com.curtinhonestly.backend.repo.CampaignEntryRepo;
 import com.curtinhonestly.backend.repo.CampaignRepo;
+import com.curtinhonestly.backend.repo.ReviewRepo;
 import com.curtinhonestly.backend.repo.UserRepo;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +35,10 @@ public class CampaignService {
     private final CampaignRepo campaignRepo;
     private final CampaignEntryRepo campaignEntryRepo;
     private final UserRepo userRepo;
+    private final ReviewRepo reviewRepo;
     private final SecureRandom secureRandom = new SecureRandom();
+
+    public record CampaignAwardResult(Optional<CampaignEntry> newEntry, CampaignProgressDTO progress) {}
 
     public Optional<Campaign> resolveCampaignForRegistration(String ref, String promoCode) {
         Campaign byRef = normalize(ref)
@@ -72,43 +77,54 @@ public class CampaignService {
         );
     }
 
-    public Optional<CampaignEntry> tryCreateEntryForReview(User user, Review review) {
-        if (user.getCampaign() == null || user.isBanned() || !user.isVerifiedStudent()) {
-            return Optional.empty();
+    public CampaignProgressDTO getCampaignProgress(User user) {
+        if (user.getCampaign() == null) {
+            return null;
+        }
+        return buildProgress(user, user.getCampaign());
+    }
+
+    public CampaignAwardResult tryAwardCampaignEntries(User user, Review triggeringReview) {
+        if (user.getCampaign() == null || user.isBanned()) {
+            return new CampaignAwardResult(Optional.empty(), null);
         }
 
         Campaign campaign = user.getCampaign();
-        if (!isWithinWindow(campaign, review.getCreatedAt())) {
-            return Optional.empty();
+        CampaignProgressDTO progress = buildProgress(user, campaign);
+
+        if (campaign.isRequireVerifiedStudent() && !user.isVerifiedStudent()) {
+            return new CampaignAwardResult(Optional.empty(), progress);
         }
 
-        String validationMessage = validateCampaignState(campaign, false);
-        if (validationMessage != null) {
-            return Optional.empty();
+        if (!reviewQualifies(triggeringReview, campaign)) {
+            return new CampaignAwardResult(Optional.empty(), progress);
         }
 
-        if (review.getReviewText() == null || review.getReviewText().trim().length() < campaign.getMinReviewLength()) {
-            return Optional.empty();
+        if (validateCampaignState(campaign, false) != null) {
+            return new CampaignAwardResult(Optional.empty(), progress);
         }
 
-        if (campaignEntryRepo.existsByReview_Id(review.getId())) {
-            return Optional.empty();
-        }
-
+        long qualifyingCount = countQualifyingReviews(user, campaign);
+        int requiredReviewCount = Math.max(1, campaign.getRequiredReviewCount());
+        int maxEntriesPerUser = Math.max(1, campaign.getMaxEntriesPerUser());
+        long entriesShouldHave = Math.min(qualifyingCount / requiredReviewCount, maxEntriesPerUser);
         long existingEntries = campaignEntryRepo.countByCampaign_IdAndUser_Id(campaign.getId(), user.getId());
-        if (existingEntries >= campaign.getMaxEntriesPerUser()) {
-            return Optional.empty();
+        long entriesToCreate = entriesShouldHave - existingEntries;
+
+        Optional<CampaignEntry> newEntry = Optional.empty();
+        for (long i = 0; i < entriesToCreate; i++) {
+            CampaignEntry entry = new CampaignEntry();
+            entry.setCampaign(campaign);
+            entry.setUser(user);
+            entry.setReview(triggeringReview);
+            entry.setEntryToken(generateUniqueEntryToken());
+            CampaignEntry saved = campaignEntryRepo.save(entry);
+            newEntry = Optional.of(saved);
+            log.info("Campaign entry {} created for user {} on review {}", saved.getEntryToken(), user.getId(), triggeringReview.getId());
         }
 
-        CampaignEntry entry = new CampaignEntry();
-        entry.setCampaign(campaign);
-        entry.setUser(user);
-        entry.setReview(review);
-        entry.setEntryToken(generateUniqueEntryToken());
-
-        CampaignEntry saved = campaignEntryRepo.save(entry);
-        log.info("Campaign entry {} created for user {} on review {}", saved.getEntryToken(), user.getId(), review.getId());
-        return Optional.of(saved);
+        progress = buildProgress(user, campaign);
+        return new CampaignAwardResult(newEntry, progress);
     }
 
     public List<CampaignEntrySummaryDTO> getEntriesForUser(User user) {
@@ -137,7 +153,9 @@ public class CampaignService {
             Instant endsAt,
             Integer maxRedemptions,
             int minReviewLength,
-            int maxEntriesPerUser
+            int maxEntriesPerUser,
+            boolean requireVerifiedStudent,
+            int requiredReviewCount
     ) {
         String normalizedSlug = requireNormalized(slug, "Campaign slug");
         String normalizedCode = requireNormalized(code, "Promo code").toUpperCase();
@@ -156,7 +174,10 @@ public class CampaignService {
             minReviewLength = 50;
         }
         if (maxEntriesPerUser <= 0) {
-            maxEntriesPerUser = 5;
+            maxEntriesPerUser = 1;
+        }
+        if (requiredReviewCount <= 0) {
+            requiredReviewCount = 1;
         }
 
         Campaign campaign = new Campaign();
@@ -169,6 +190,8 @@ public class CampaignService {
         campaign.setMaxRedemptions(maxRedemptions);
         campaign.setMinReviewLength(minReviewLength);
         campaign.setMaxEntriesPerUser(maxEntriesPerUser);
+        campaign.setRequireVerifiedStudent(requireVerifiedStudent);
+        campaign.setRequiredReviewCount(requiredReviewCount);
         campaign.setActive(true);
 
         return toAdminDTO(campaignRepo.save(campaign));
@@ -197,6 +220,35 @@ public class CampaignService {
                 .toList();
     }
 
+    private long countQualifyingReviews(User user, Campaign campaign) {
+        return reviewRepo.findByUser_IdOrderByCreatedAtDesc(user.getId()).stream()
+                .filter(review -> reviewQualifies(review, campaign))
+                .count();
+    }
+
+    private boolean reviewQualifies(Review review, Campaign campaign) {
+        if (!isWithinWindow(campaign, review.getCreatedAt())) {
+            return false;
+        }
+        return review.getReviewText() != null
+                && review.getReviewText().trim().length() >= campaign.getMinReviewLength();
+    }
+
+    private CampaignProgressDTO buildProgress(User user, Campaign campaign) {
+        long qualifyingReviews = countQualifyingReviews(user, campaign);
+        int requiredReviewCount = Math.max(1, campaign.getRequiredReviewCount());
+        int maxEntriesPerUser = Math.max(1, campaign.getMaxEntriesPerUser());
+        long entriesEarned = Math.min(qualifyingReviews / requiredReviewCount, maxEntriesPerUser);
+
+        return new CampaignProgressDTO(
+                (int) qualifyingReviews,
+                requiredReviewCount,
+                (int) entriesEarned,
+                maxEntriesPerUser,
+                campaign.isRequireVerifiedStudent()
+        );
+    }
+
     private CampaignAdminDTO toAdminDTO(Campaign campaign) {
         return new CampaignAdminDTO(
                 campaign.getId(),
@@ -210,6 +262,8 @@ public class CampaignService {
                 campaign.getMaxRedemptions(),
                 campaign.getMinReviewLength(),
                 campaign.getMaxEntriesPerUser(),
+                campaign.isRequireVerifiedStudent(),
+                campaign.getRequiredReviewCount(),
                 userRepo.countByCampaign_Id(campaign.getId()),
                 campaignEntryRepo.countByCampaign_Id(campaign.getId()),
                 campaign.getCreatedAt()

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -1,0 +1,272 @@
+package com.curtinhonestly.backend.service;
+
+import com.curtinhonestly.backend.domain.Campaign;
+import com.curtinhonestly.backend.domain.CampaignEntry;
+import com.curtinhonestly.backend.domain.Review;
+import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.dto.CampaignAdminDTO;
+import com.curtinhonestly.backend.dto.CampaignEntryAdminDTO;
+import com.curtinhonestly.backend.dto.CampaignEntrySummaryDTO;
+import com.curtinhonestly.backend.dto.CampaignValidationDTO;
+import com.curtinhonestly.backend.repo.CampaignEntryRepo;
+import com.curtinhonestly.backend.repo.CampaignRepo;
+import com.curtinhonestly.backend.repo.UserRepo;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(rollbackOn = Exception.class)
+public class CampaignService {
+
+    private static final String TOKEN_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final int TOKEN_SUFFIX_LENGTH = 8;
+
+    private final CampaignRepo campaignRepo;
+    private final CampaignEntryRepo campaignEntryRepo;
+    private final UserRepo userRepo;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public Optional<Campaign> resolveCampaignForRegistration(String ref, String promoCode) {
+        Campaign byRef = normalize(ref)
+                .flatMap(campaignRepo::findBySlugIgnoreCase)
+                .orElse(null);
+        Campaign byCode = normalize(promoCode)
+                .flatMap(campaignRepo::findByCodeIgnoreCase)
+                .orElse(null);
+
+        if (byRef != null && byCode != null && !byRef.getId().equals(byCode.getId())) {
+            throw new IllegalArgumentException("Referral link and promo code belong to different campaigns.");
+        }
+
+        Campaign campaign = byRef != null ? byRef : byCode;
+        return Optional.ofNullable(campaign);
+    }
+
+    public CampaignValidationDTO validateCampaign(String ref, String promoCode) {
+        Optional<Campaign> campaignOpt = resolveCampaignForRegistration(ref, promoCode);
+        if (campaignOpt.isEmpty()) {
+            return new CampaignValidationDTO(false, "Campaign not found.", null, null, null);
+        }
+
+        Campaign campaign = campaignOpt.get();
+        String message = validateCampaignState(campaign, true);
+        if (message != null) {
+            return new CampaignValidationDTO(false, message, campaign.getName(), campaign.getPrizeDescription(), campaign.getEndsAt());
+        }
+
+        return new CampaignValidationDTO(
+                true,
+                "Campaign is active.",
+                campaign.getName(),
+                campaign.getPrizeDescription(),
+                campaign.getEndsAt()
+        );
+    }
+
+    public Optional<CampaignEntry> tryCreateEntryForReview(User user, Review review) {
+        if (user.getCampaign() == null || user.isBanned() || !user.isVerifiedStudent()) {
+            return Optional.empty();
+        }
+
+        Campaign campaign = user.getCampaign();
+        if (!isWithinWindow(campaign, review.getCreatedAt())) {
+            return Optional.empty();
+        }
+
+        String validationMessage = validateCampaignState(campaign, false);
+        if (validationMessage != null) {
+            return Optional.empty();
+        }
+
+        if (review.getReviewText() == null || review.getReviewText().trim().length() < campaign.getMinReviewLength()) {
+            return Optional.empty();
+        }
+
+        if (campaignEntryRepo.existsByReview_Id(review.getId())) {
+            return Optional.empty();
+        }
+
+        long existingEntries = campaignEntryRepo.countByCampaign_IdAndUser_Id(campaign.getId(), user.getId());
+        if (existingEntries >= campaign.getMaxEntriesPerUser()) {
+            return Optional.empty();
+        }
+
+        CampaignEntry entry = new CampaignEntry();
+        entry.setCampaign(campaign);
+        entry.setUser(user);
+        entry.setReview(review);
+        entry.setEntryToken(generateUniqueEntryToken());
+
+        CampaignEntry saved = campaignEntryRepo.save(entry);
+        log.info("Campaign entry {} created for user {} on review {}", saved.getEntryToken(), user.getId(), review.getId());
+        return Optional.of(saved);
+    }
+
+    public List<CampaignEntrySummaryDTO> getEntriesForUser(User user) {
+        return campaignEntryRepo.findByUser_IdOrderByCreatedAtDesc(user.getId()).stream()
+                .map(entry -> new CampaignEntrySummaryDTO(
+                        entry.getEntryToken(),
+                        entry.getCampaign().getName(),
+                        entry.getReview().getUnit().getCode(),
+                        entry.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    public List<CampaignAdminDTO> listCampaigns() {
+        return campaignRepo.findAllByOrderByCreatedAtDesc().stream()
+                .map(this::toAdminDTO)
+                .toList();
+    }
+
+    public CampaignAdminDTO createCampaign(
+            String slug,
+            String code,
+            String name,
+            String prizeDescription,
+            Instant startsAt,
+            Instant endsAt,
+            Integer maxRedemptions,
+            int minReviewLength,
+            int maxEntriesPerUser
+    ) {
+        String normalizedSlug = requireNormalized(slug, "Campaign slug");
+        String normalizedCode = requireNormalized(code, "Promo code").toUpperCase();
+
+        if (campaignRepo.findBySlugIgnoreCase(normalizedSlug).isPresent()) {
+            throw new IllegalArgumentException("A campaign with that slug already exists.");
+        }
+        if (campaignRepo.findByCodeIgnoreCase(normalizedCode).isPresent()) {
+            throw new IllegalArgumentException("A campaign with that promo code already exists.");
+        }
+        if (!endsAt.isAfter(startsAt)) {
+            throw new IllegalArgumentException("Campaign end date must be after the start date.");
+        }
+
+        if (minReviewLength <= 0) {
+            minReviewLength = 50;
+        }
+        if (maxEntriesPerUser <= 0) {
+            maxEntriesPerUser = 5;
+        }
+
+        Campaign campaign = new Campaign();
+        campaign.setSlug(normalizedSlug);
+        campaign.setCode(normalizedCode);
+        campaign.setName(name.trim());
+        campaign.setPrizeDescription(prizeDescription != null ? prizeDescription.trim() : null);
+        campaign.setStartsAt(startsAt);
+        campaign.setEndsAt(endsAt);
+        campaign.setMaxRedemptions(maxRedemptions);
+        campaign.setMinReviewLength(minReviewLength);
+        campaign.setMaxEntriesPerUser(maxEntriesPerUser);
+        campaign.setActive(true);
+
+        return toAdminDTO(campaignRepo.save(campaign));
+    }
+
+    public CampaignAdminDTO setCampaignActive(String campaignId, boolean active) {
+        Campaign campaign = campaignRepo.findById(campaignId)
+                .orElseThrow(() -> new IllegalArgumentException("Campaign not found."));
+        campaign.setActive(active);
+        return toAdminDTO(campaignRepo.save(campaign));
+    }
+
+    public List<CampaignEntryAdminDTO> listEntriesForCampaign(String campaignId) {
+        if (!campaignRepo.existsById(campaignId)) {
+            throw new IllegalArgumentException("Campaign not found.");
+        }
+
+        return campaignEntryRepo.findByCampaign_IdOrderByCreatedAtDesc(campaignId).stream()
+                .map(entry -> new CampaignEntryAdminDTO(
+                        entry.getId(),
+                        entry.getEntryToken(),
+                        entry.getUser().getEmail(),
+                        entry.getReview().getUnit().getCode(),
+                        entry.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    private CampaignAdminDTO toAdminDTO(Campaign campaign) {
+        return new CampaignAdminDTO(
+                campaign.getId(),
+                campaign.getSlug(),
+                campaign.getCode(),
+                campaign.getName(),
+                campaign.getPrizeDescription(),
+                campaign.getStartsAt(),
+                campaign.getEndsAt(),
+                campaign.isActive(),
+                campaign.getMaxRedemptions(),
+                campaign.getMinReviewLength(),
+                campaign.getMaxEntriesPerUser(),
+                userRepo.countByCampaign_Id(campaign.getId()),
+                campaignEntryRepo.countByCampaign_Id(campaign.getId()),
+                campaign.getCreatedAt()
+        );
+    }
+
+    private String validateCampaignState(Campaign campaign, boolean checkRedemptions) {
+        if (!campaign.isActive()) {
+            return "This campaign is no longer active.";
+        }
+        Instant now = Instant.now();
+        if (now.isBefore(campaign.getStartsAt())) {
+            return "This campaign has not started yet.";
+        }
+        if (now.isAfter(campaign.getEndsAt())) {
+            return "This campaign has ended.";
+        }
+        if (checkRedemptions && campaign.getMaxRedemptions() != null) {
+            long currentSignups = userRepo.countByCampaign_Id(campaign.getId());
+            if (currentSignups >= campaign.getMaxRedemptions()) {
+                return "This campaign has reached its signup limit.";
+            }
+        }
+        return null;
+    }
+
+    private boolean isWithinWindow(Campaign campaign, Instant timestamp) {
+        return !timestamp.isBefore(campaign.getStartsAt()) && !timestamp.isAfter(campaign.getEndsAt());
+    }
+
+    private String generateUniqueEntryToken() {
+        for (int attempt = 0; attempt < 10; attempt++) {
+            String token = "CH-" + randomTokenSuffix();
+            if (campaignEntryRepo.findByEntryTokenIgnoreCase(token).isEmpty()) {
+                return token;
+            }
+        }
+        throw new IllegalStateException("Unable to generate a unique campaign entry token.");
+    }
+
+    private String randomTokenSuffix() {
+        StringBuilder builder = new StringBuilder(TOKEN_SUFFIX_LENGTH);
+        for (int i = 0; i < TOKEN_SUFFIX_LENGTH; i++) {
+            builder.append(TOKEN_CHARS.charAt(secureRandom.nextInt(TOKEN_CHARS.length())));
+        }
+        return builder.toString();
+    }
+
+    private Optional<String> normalize(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? Optional.empty() : Optional.of(trimmed);
+    }
+
+    private String requireNormalized(String value, String label) {
+        return normalize(value).orElseThrow(() -> new IllegalArgumentException(label + " is required."));
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.curtinhonestly.backend.service;
 
+import com.curtinhonestly.backend.domain.CampaignEntry;
 import com.curtinhonestly.backend.domain.Review;
 import com.curtinhonestly.backend.domain.Unit;
 import com.curtinhonestly.backend.domain.User;
@@ -16,6 +17,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -28,6 +30,7 @@ public class ReviewService {
     private final UserRepo userRepo;
     private final UnitRepo unitRepo;
     private final ProfanityFilterService profanityFilterService;
+    private final CampaignService campaignService;
 
     public List<Review> getReviewsByUnitCode(String unitCode) {
         Unit unit = unitService.getUnitByCode(unitCode);
@@ -43,7 +46,6 @@ public class ReviewService {
     }
 
     public Review createReview(Review review) {
-        // Get authenticated user's email
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
         // Load User entity
@@ -81,8 +83,17 @@ public class ReviewService {
 
         log.info("Review added by user: {}", username);
 
-        return reviewRepo.save(review);
+        Review savedReview = reviewRepo.save(review);
+        return savedReview;
     }
+
+    public ReviewCreationResult createReviewWithCampaignEntry(Review review) {
+        Review savedReview = createReview(review);
+        Optional<CampaignEntry> entry = campaignService.tryCreateEntryForReview(savedReview.getUser(), savedReview);
+        return new ReviewCreationResult(savedReview, entry);
+    }
+
+    public record ReviewCreationResult(Review review, Optional<CampaignEntry> campaignEntry) {}
 
     public void deleteReview(Review review) {
         log.info("Review deleted");

--- a/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
@@ -4,6 +4,7 @@ import com.curtinhonestly.backend.domain.CampaignEntry;
 import com.curtinhonestly.backend.domain.Review;
 import com.curtinhonestly.backend.domain.Unit;
 import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.dto.CampaignProgressDTO;
 import com.curtinhonestly.backend.repo.ReviewRepo;
 import com.curtinhonestly.backend.repo.UnitRepo;
 import com.curtinhonestly.backend.repo.UserRepo;
@@ -45,55 +46,77 @@ public class ReviewService {
         return reviewRepo.findById(id).orElseThrow(() -> new RuntimeException("Review not found"));
     }
 
+    public Optional<Review> getReviewForCurrentUserAndUnit(String unitCode) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepo.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found: " + email));
+        Unit unit = unitRepo.findByCode(unitCode)
+                .orElseThrow(() -> new RuntimeException("Unit not found with code: " + unitCode));
+        return reviewRepo.findByUser_IdAndUnit_Id(user.getId(), unit.getId());
+    }
+
     public Review createReview(Review review) {
-        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = getCurrentUser();
+        validateReviewFields(review);
 
-        // Load User entity
-        User user = userRepo.findByEmail(username)
-                .orElseThrow(() -> new RuntimeException("User not found: " + username));
-
-        // Validate rating scale (0-5)
-        if (review.getRating() < 0 || review.getRating() > 5) {
-            throw new IllegalArgumentException("Rating must be between 0 and 5");
-        }
-
-        // Validate grade scale (0-100)
-        if (review.getFinalGrade() != null && (review.getFinalGrade() < 0 || review.getFinalGrade() > 100)) {
-            throw new IllegalArgumentException("Final grade must be between 0 and 100%");
-        }
-
-        // Check for profanity
-        if (profanityFilterService.containsProfanity(review.getReviewText())) {
-            throw new IllegalArgumentException("Review contains inappropriate language. Please keep it professional.");
-        }
-
-        // Extract unit code from incoming Review object
         if (review.getUnit() == null || review.getUnit().getCode() == null) {
             throw new IllegalArgumentException("Unit code must be provided in review");
         }
-        String unitCode = review.getUnit().getCode();
 
-        // Look up full Unit entity by code
-        Unit unit = unitRepo.findByCode(unitCode)
-                .orElseThrow(() -> new RuntimeException("Unit not found with code: " + unitCode));
+        Unit unit = unitRepo.findByCode(review.getUnit().getCode())
+                .orElseThrow(() -> new RuntimeException("Unit not found with code: " + review.getUnit().getCode()));
 
-        // Set the full Unit and User entities on the review before saving
+        if (reviewRepo.existsByUser_IdAndUnit_Id(user.getId(), unit.getId())) {
+            throw new IllegalArgumentException("You have already reviewed this unit. Edit your existing review instead.");
+        }
+
         review.setUnit(unit);
         review.setUser(user);
 
-        log.info("Review added by user: {}", username);
+        log.info("Review added by user: {}", user.getEmail());
+        return reviewRepo.save(review);
+    }
 
-        Review savedReview = reviewRepo.save(review);
-        return savedReview;
+    public Review updateReview(String reviewId, Review updates) {
+        User user = getCurrentUser();
+        Review existing = getReviewById(reviewId);
+
+        if (!existing.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("You can only edit your own reviews.");
+        }
+
+        validateReviewFields(updates);
+
+        existing.setRating(updates.getRating());
+        existing.setFinalGrade(updates.getFinalGrade());
+        existing.setReviewText(updates.getReviewText());
+        existing.setSemesterTaken(updates.getSemesterTaken());
+        existing.setProfessor(updates.getProfessor());
+        existing.setWorkload(updates.getWorkload());
+        existing.setHasExam(updates.isHasExam());
+        existing.setWouldTakeAgain(updates.isWouldTakeAgain());
+
+        log.info("Review updated by user: {}", user.getEmail());
+        return reviewRepo.save(existing);
     }
 
     public ReviewCreationResult createReviewWithCampaignEntry(Review review) {
         Review savedReview = createReview(review);
-        Optional<CampaignEntry> entry = campaignService.tryCreateEntryForReview(savedReview.getUser(), savedReview);
-        return new ReviewCreationResult(savedReview, entry);
+        CampaignService.CampaignAwardResult award = campaignService.tryAwardCampaignEntries(savedReview.getUser(), savedReview);
+        return new ReviewCreationResult(savedReview, award.newEntry(), award.progress());
     }
 
-    public record ReviewCreationResult(Review review, Optional<CampaignEntry> campaignEntry) {}
+    public ReviewCreationResult updateReviewWithCampaignEntry(String reviewId, Review updates) {
+        Review savedReview = updateReview(reviewId, updates);
+        CampaignService.CampaignAwardResult award = campaignService.tryAwardCampaignEntries(savedReview.getUser(), savedReview);
+        return new ReviewCreationResult(savedReview, award.newEntry(), award.progress());
+    }
+
+    public record ReviewCreationResult(
+            Review review,
+            Optional<CampaignEntry> campaignEntry,
+            CampaignProgressDTO campaignProgress
+    ) {}
 
     public void deleteReview(Review review) {
         log.info("Review deleted");
@@ -114,5 +137,25 @@ public class ReviewService {
         User user = userRepo.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("User not found: " + email));
         return reviewRepo.findByUser_IdOrderByCreatedAtDesc(user.getId());
+    }
+
+    private User getCurrentUser() {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepo.findByEmail(username)
+                .orElseThrow(() -> new RuntimeException("User not found: " + username));
+    }
+
+    private void validateReviewFields(Review review) {
+        if (review.getRating() < 0 || review.getRating() > 5) {
+            throw new IllegalArgumentException("Rating must be between 0 and 5");
+        }
+
+        if (review.getFinalGrade() != null && (review.getFinalGrade() < 0 || review.getFinalGrade() > 100)) {
+            throw new IllegalArgumentException("Final grade must be between 0 and 100%");
+        }
+
+        if (profanityFilterService.containsProfanity(review.getReviewText())) {
+            throw new IllegalArgumentException("Review contains inappropriate language. Please keep it professional.");
+        }
     }
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/service/UserService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/UserService.java
@@ -1,5 +1,6 @@
 package com.curtinhonestly.backend.service;
 
+import com.curtinhonestly.backend.domain.Campaign;
 import com.curtinhonestly.backend.domain.User;
 import com.curtinhonestly.backend.domain.UserRole;
 import com.curtinhonestly.backend.repo.UserRepo;
@@ -21,6 +22,10 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public User createUser(String email, String password) {
+        return createUser(email, password, null, null);
+    }
+
+    public User createUser(String email, String password, Campaign campaign, String ref) {
         log.info("Creating user: {}", email);
         User user = new User();
         user.setEmail(email);
@@ -28,8 +33,15 @@ public class UserService {
         user.setVerifiedStudent(StudentEmailValidator.isStudentEmail(email));
         user.setRoles(List.of(UserRole.ROLE_USER));
 
+        if (campaign != null) {
+            user.setCampaign(campaign);
+            user.setRegisteredViaRef(ref != null && !ref.isBlank() ? ref.trim() : campaign.getSlug());
+        }
+
         User savedUser = userRepo.saveAndFlush(user);
-        log.info("User created successfully with ID: {}, verifiedStudent={}", savedUser.getId(), savedUser.isVerifiedStudent());
+        log.info("User created successfully with ID: {}, verifiedStudent={}, campaign={}",
+                savedUser.getId(), savedUser.isVerifiedStudent(),
+                campaign != null ? campaign.getSlug() : "none");
         return savedUser;
     }
 

--- a/frontend/src/app/components/account/account.component.css
+++ b/frontend/src/app/components/account/account.component.css
@@ -118,6 +118,12 @@
   line-height: 1.5;
 }
 
+.campaign-progress {
+  margin: 12px 0 0;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
 .entries-heading {
   margin: 16px 0 8px;
   font-size: 1rem;

--- a/frontend/src/app/components/account/account.component.css
+++ b/frontend/src/app/components/account/account.component.css
@@ -108,6 +108,51 @@
   font-size: 0.9rem;
 }
 
+.campaign-section {
+  border-color: #bfdbfe;
+}
+
+.campaign-note {
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.entries-heading {
+  margin: 16px 0 8px;
+  font-size: 1rem;
+}
+
+.entry-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.entry-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.entry-list li:last-child {
+  border-bottom: none;
+}
+
+.entry-token {
+  font-family: monospace;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #1d4ed8;
+}
+
+.entry-meta {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
 .page-footer {
   margin-top: 8px;
   font-size: 0.9rem;

--- a/frontend/src/app/components/account/account.component.html
+++ b/frontend/src/app/components/account/account.component.html
@@ -27,6 +27,39 @@
     </dl>
   </section>
 
+  @if (account()?.campaignName) {
+    <section class="account-section card campaign-section">
+      <h2>Campaign</h2>
+      <p class="section-hint">
+        You joined via <strong>{{ account()?.campaignName }}</strong>.
+        @if (account()?.campaignPrizeDescription) {
+          Prize: {{ account()?.campaignPrizeDescription }}.
+        }
+        @if (account()?.campaignEndsAt) {
+          Draw entries close {{ account()?.campaignEndsAt | date: 'mediumDate' }}.
+        }
+      </p>
+
+      @if (!authService.verifiedStudent()) {
+        <p class="campaign-note">Verify your student email below to earn draw entries when you leave qualifying reviews.</p>
+      }
+
+      @if (account()?.campaignEntries?.length) {
+        <h3 class="entries-heading">Your draw entries</h3>
+        <ul class="entry-list">
+          @for (entry of account()?.campaignEntries; track entry.entryToken) {
+            <li>
+              <span class="entry-token">{{ entry.entryToken }}</span>
+              <span class="entry-meta">{{ entry.unitCode }} · {{ entry.createdAt | date: 'medium' }}</span>
+            </li>
+          }
+        </ul>
+      } @else if (authService.verifiedStudent()) {
+        <p class="campaign-note">Leave a qualifying review on any unit to receive an entry token.</p>
+      }
+    </section>
+  }
+
   <section class="account-section card">
     <h2>Update email</h2>
     <p class="section-hint">Change the email you use to sign in. You will need your current password.</p>

--- a/frontend/src/app/components/account/account.component.html
+++ b/frontend/src/app/components/account/account.component.html
@@ -40,8 +40,14 @@
         }
       </p>
 
-      @if (!authService.verifiedStudent()) {
+      @if (account()?.campaignProgress?.requireVerifiedStudent && !authService.verifiedStudent()) {
         <p class="campaign-note">Verify your student email below to earn draw entries when you leave qualifying reviews.</p>
+      } @else if (account()?.campaignProgress && !account()?.campaignProgress?.requireVerifiedStudent) {
+        <p class="campaign-note">This campaign accepts unverified accounts (e.g. alumni). One review per unit counts toward your entry.</p>
+      }
+
+      @if (campaignProgressLabel()) {
+        <p class="campaign-progress">{{ campaignProgressLabel() }}</p>
       }
 
       @if (account()?.campaignEntries?.length) {
@@ -54,8 +60,8 @@
             </li>
           }
         </ul>
-      } @else if (authService.verifiedStudent()) {
-        <p class="campaign-note">Leave a qualifying review on any unit to receive an entry token.</p>
+      } @else if (authService.verifiedStudent() || !account()?.campaignProgress?.requireVerifiedStudent) {
+        <p class="campaign-note">Leave qualifying reviews on different units to receive a draw entry token.</p>
       }
     </section>
   }

--- a/frontend/src/app/components/account/account.component.ts
+++ b/frontend/src/app/components/account/account.component.ts
@@ -1,19 +1,21 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { AuthService } from '../../services/auth.service';
+import { AuthService, AccountStatus } from '../../services/auth.service';
 
 @Component({
   selector: 'app-account',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, DatePipe],
   templateUrl: './account.component.html',
   styleUrl: './account.component.css'
 })
 export class AccountComponent implements OnInit {
   protected authService = inject(AuthService);
   private router = inject(Router);
+
+  account = signal<AccountStatus | null>(null);
 
   newEmail = '';
   emailPassword = '';
@@ -32,6 +34,7 @@ export class AccountComponent implements OnInit {
     }
 
     this.authService.refreshAccountStatus().subscribe({
+      next: (status) => this.account.set(status),
       error: () => this.authService.logout()
     });
   }
@@ -49,6 +52,7 @@ export class AccountComponent implements OnInit {
         this.successMessage.set('Email updated successfully.');
         this.newEmail = '';
         this.emailPassword = '';
+        this.refreshAccount();
       },
       error: (err) => {
         this.isLoading.set(false);
@@ -75,6 +79,7 @@ export class AccountComponent implements OnInit {
         this.successMessage.set('Your account is now verified as a Curtin student.');
         this.studentEmail = '';
         this.verifyPassword = '';
+        this.refreshAccount();
       },
       error: (err) => {
         this.isLoading.set(false);
@@ -101,6 +106,12 @@ export class AccountComponent implements OnInit {
         this.isLoading.set(false);
         this.errorMessage.set(err.error?.error || 'Failed to delete account.');
       }
+    });
+  }
+
+  private refreshAccount() {
+    this.authService.refreshAccountStatus().subscribe({
+      next: (status) => this.account.set(status)
     });
   }
 

--- a/frontend/src/app/components/account/account.component.ts
+++ b/frontend/src/app/components/account/account.component.ts
@@ -39,6 +39,29 @@ export class AccountComponent implements OnInit {
     });
   }
 
+  campaignProgressLabel(): string | null {
+    const progress = this.account()?.campaignProgress;
+    if (!progress) {
+      return null;
+    }
+
+    if (progress.entriesEarned >= progress.maxEntries) {
+      return `You have ${progress.entriesEarned} draw ${progress.entriesEarned === 1 ? 'entry' : 'entries'}.`;
+    }
+
+    const remainder = progress.qualifyingReviews % progress.requiredReviews;
+    if (remainder === 0 && progress.qualifyingReviews === 0) {
+      return `Leave ${progress.requiredReviews} qualifying review${progress.requiredReviews === 1 ? '' : 's'} on different units to enter the draw.`;
+    }
+
+    if (remainder === 0) {
+      return `${progress.qualifyingReviews} qualifying reviews submitted.`;
+    }
+
+    const needed = progress.requiredReviews - remainder;
+    return `${progress.qualifyingReviews}/${progress.requiredReviews} qualifying reviews — ${needed} more needed for a draw entry.`;
+  }
+
   onUpdateEmail() {
     this.clearMessages();
     this.isLoading.set(true);

--- a/frontend/src/app/components/add-review/add-review.component.css
+++ b/frontend/src/app/components/add-review/add-review.component.css
@@ -128,6 +128,16 @@
   border: 1px solid #feb2b2;
 }
 
+.success-box {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  padding: 12px;
+  border-radius: var(--radius-none);
+  margin-bottom: 15px;
+  border: 1px solid #bfdbfe;
+  line-height: 1.5;
+}
+
 .btn-secondary {
   background-color: var(--surface-muted);
   color: var(--text-primary);

--- a/frontend/src/app/components/add-review/add-review.component.html
+++ b/frontend/src/app/components/add-review/add-review.component.html
@@ -1,5 +1,5 @@
 <div class="review-form-container">
-  <h3>Add a Review for {{ unitCode() }}</h3>
+  <h3>{{ isEditing() ? 'Edit' : 'Add' }} a Review for {{ unitCode() }}</h3>
   <form (ngSubmit)="onSubmit()" #reviewForm="ngForm">
     
     <div class="form-grid">
@@ -73,7 +73,7 @@
     <div class="form-actions">
       <button type="button" (click)="onCancel()" class="btn btn-secondary" [disabled]="isLoading()">Cancel</button>
       <button type="submit" class="btn btn-primary" [disabled]="isLoading() || !reviewText() || reviewText().length < 10">
-        {{ isLoading() ? 'Submitting...' : 'Post Review' }}
+        {{ isLoading() ? (isEditing() ? 'Saving...' : 'Submitting...') : (isEditing() ? 'Save changes' : 'Post Review') }}
       </button>
     </div>
   </form>

--- a/frontend/src/app/components/add-review/add-review.component.html
+++ b/frontend/src/app/components/add-review/add-review.component.html
@@ -66,6 +66,10 @@
       {{ errorMessage() }}
     </div>
 
+    @if (successMessage()) {
+      <div class="success-box">{{ successMessage() }}</div>
+    }
+
     <div class="form-actions">
       <button type="button" (click)="onCancel()" class="btn btn-secondary" [disabled]="isLoading()">Cancel</button>
       <button type="submit" class="btn btn-primary" [disabled]="isLoading() || !reviewText() || reviewText().length < 10">

--- a/frontend/src/app/components/add-review/add-review.component.ts
+++ b/frontend/src/app/components/add-review/add-review.component.ts
@@ -1,8 +1,9 @@
-import { Component, inject, input, output, signal } from '@angular/core';
+import { Component, effect, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ReviewService, CreateReviewResponse } from '../../services/review.service';
+import { CampaignProgress, CreateReviewResponse, ReviewService } from '../../services/review.service';
 import { BANNED_WORDS } from '../../models/profanity-list';
+import { MyReview } from '../../models/unit.model';
 
 @Component({
   selector: 'app-add-review',
@@ -15,6 +16,7 @@ export class AddReviewComponent {
   private reviewService = inject(ReviewService);
 
   unitCode = input.required<string>();
+  editReview = input<MyReview | null>(null);
   reviewAdded = output<void>();
   cancel = output<void>();
 
@@ -32,9 +34,30 @@ export class AddReviewComponent {
   successMessage = signal<string | null>(null);
 
   private readonly profanityRegex = new RegExp(
-    `\\b(${BANNED_WORDS.map(word => this.escapeRegExp(word)).join('|')})\\b`, 
+    `\\b(${BANNED_WORDS.map(word => this.escapeRegExp(word)).join('|')})\\b`,
     'i'
   );
+
+  constructor() {
+    effect(() => {
+      const existing = this.editReview();
+      if (!existing) {
+        return;
+      }
+      this.rating.set(existing.rating);
+      this.reviewText.set(existing.reviewText);
+      this.semesterTaken.set(existing.semesterTaken);
+      this.professor.set(existing.professor ?? '');
+      this.workload.set(existing.workload ?? 5);
+      this.hasExam.set(existing.hasExam ?? false);
+      this.wouldTakeAgain.set(existing.wouldTakeAgain ?? true);
+      this.finalGrade.set(existing.finalGrade ?? null);
+    });
+  }
+
+  isEditing(): boolean {
+    return !!this.editReview()?.id;
+  }
 
   private escapeRegExp(string: string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -77,28 +100,75 @@ export class AddReviewComponent {
       unit: { code: this.unitCode() }
     };
 
-    this.reviewService.createReview(reviewData).subscribe({
+    const request = this.isEditing()
+      ? this.reviewService.updateReview(this.editReview()!.id, reviewData)
+      : this.reviewService.createReview(reviewData);
+
+    request.subscribe({
       next: (response: CreateReviewResponse) => {
         this.isLoading.set(false);
-
-        if (response.campaignEntryToken) {
-          this.successMessage.set(
-            `Review submitted! You're entered in the ${response.campaignName ?? 'campaign'} draw. Entry token: ${response.campaignEntryToken}`
-          );
-          setTimeout(() => {
-            this.reviewAdded.emit();
-            this.resetForm();
-          }, 4000);
-        } else {
-          this.reviewAdded.emit();
-          this.resetForm();
-        }
+        this.handleSuccess(response);
       },
       error: (err) => {
         this.isLoading.set(false);
         this.errorMessage.set(err.error?.error || 'Failed to submit review. Please try again.');
       }
     });
+  }
+
+  private handleSuccess(response: CreateReviewResponse) {
+    const progressMessage = this.buildProgressMessage(response.campaignProgress);
+
+    if (response.campaignEntryToken) {
+      this.successMessage.set(
+        `Review ${this.isEditing() ? 'updated' : 'submitted'}! You're entered in the ${response.campaignName ?? 'campaign'} draw. Entry token: ${response.campaignEntryToken}`
+      );
+      setTimeout(() => {
+        this.reviewAdded.emit();
+        if (!this.isEditing()) {
+          this.resetForm();
+        }
+      }, 4000);
+      return;
+    }
+
+    if (progressMessage) {
+      this.successMessage.set(`Review ${this.isEditing() ? 'updated' : 'submitted'}! ${progressMessage}`);
+      setTimeout(() => {
+        this.reviewAdded.emit();
+        if (!this.isEditing()) {
+          this.resetForm();
+        }
+      }, 3000);
+      return;
+    }
+
+    this.reviewAdded.emit();
+    if (!this.isEditing()) {
+      this.resetForm();
+    }
+  }
+
+  private buildProgressMessage(progress: CampaignProgress | null): string | null {
+    if (!progress) {
+      return null;
+    }
+
+    if (progress.requireVerifiedStudent && progress.entriesEarned === 0 && progress.qualifyingReviews > 0) {
+      return 'Verify your student email to earn draw entries.';
+    }
+
+    if (progress.entriesEarned >= progress.maxEntries) {
+      return 'You have earned the maximum draw entries for this campaign.';
+    }
+
+    const remainder = progress.qualifyingReviews % progress.requiredReviews;
+    if (remainder !== 0) {
+      const needed = progress.requiredReviews - remainder;
+      return `${needed} more qualifying review${needed === 1 ? '' : 's'} needed for a draw entry (${progress.qualifyingReviews}/${progress.requiredReviews}).`;
+    }
+
+    return null;
   }
 
   resetForm() {

--- a/frontend/src/app/components/add-review/add-review.component.ts
+++ b/frontend/src/app/components/add-review/add-review.component.ts
@@ -1,8 +1,7 @@
 import { Component, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ReviewService } from '../../services/review.service';
-import { Router } from '@angular/router';
+import { ReviewService, CreateReviewResponse } from '../../services/review.service';
 import { BANNED_WORDS } from '../../models/profanity-list';
 
 @Component({
@@ -14,13 +13,11 @@ import { BANNED_WORDS } from '../../models/profanity-list';
 })
 export class AddReviewComponent {
   private reviewService = inject(ReviewService);
-  private router = inject(Router);
 
   unitCode = input.required<string>();
   reviewAdded = output<void>();
   cancel = output<void>();
 
-  // Form fields
   rating = signal(5);
   reviewText = signal('');
   semesterTaken = signal('Semester 1, 2026');
@@ -32,15 +29,15 @@ export class AddReviewComponent {
 
   isLoading = signal(false);
   errorMessage = signal<string | null>(null);
+  successMessage = signal<string | null>(null);
 
-  // Pre-compile the profanity regex once
   private readonly profanityRegex = new RegExp(
     `\\b(${BANNED_WORDS.map(word => this.escapeRegExp(word)).join('|')})\\b`, 
     'i'
   );
 
   private escapeRegExp(string: string) {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
   private containsProfanity(text: string): boolean {
@@ -54,13 +51,11 @@ export class AddReviewComponent {
       return;
     }
 
-    // Validate Grade
     if (this.finalGrade() !== null && (this.finalGrade()! < 0 || this.finalGrade()! > 100)) {
       this.errorMessage.set('Final grade must be between 0 and 100%.');
       return;
     }
 
-    // Profanity Check
     if (this.containsProfanity(this.reviewText())) {
       this.errorMessage.set('Your review contains language that violates our community standards. Please keep it professional.');
       return;
@@ -68,6 +63,7 @@ export class AddReviewComponent {
 
     this.isLoading.set(true);
     this.errorMessage.set(null);
+    this.successMessage.set(null);
 
     const reviewData = {
       rating: this.rating(),
@@ -82,11 +78,21 @@ export class AddReviewComponent {
     };
 
     this.reviewService.createReview(reviewData).subscribe({
-      next: () => {
+      next: (response: CreateReviewResponse) => {
         this.isLoading.set(false);
-        this.reviewAdded.emit();
-        // Reset form
-        this.resetForm();
+
+        if (response.campaignEntryToken) {
+          this.successMessage.set(
+            `Review submitted! You're entered in the ${response.campaignName ?? 'campaign'} draw. Entry token: ${response.campaignEntryToken}`
+          );
+          setTimeout(() => {
+            this.reviewAdded.emit();
+            this.resetForm();
+          }, 4000);
+        } else {
+          this.reviewAdded.emit();
+          this.resetForm();
+        }
       },
       error: (err) => {
         this.isLoading.set(false);
@@ -104,6 +110,7 @@ export class AddReviewComponent {
     this.hasExam.set(false);
     this.wouldTakeAgain.set(true);
     this.finalGrade.set(null);
+    this.successMessage.set(null);
   }
 
   onCancel() {

--- a/frontend/src/app/components/my-reviews/my-reviews.component.html
+++ b/frontend/src/app/components/my-reviews/my-reviews.component.html
@@ -21,11 +21,11 @@
   @if (showAddFlow()) {
     <section class="add-flow card">
       <div class="add-flow-header">
-        <h2>Add a review</h2>
+        <h2>{{ editingReview() ? 'Edit review' : 'Add a review' }}</h2>
         <button type="button" class="btn-text" (click)="cancelAddReview()">Cancel</button>
       </div>
 
-      @if (!selectedUnitCode()) {
+      @if (!editingReview() && !selectedUnitCode()) {
         <p class="section-hint">Search for a unit, then select one to write your review.</p>
         <input
           type="text"
@@ -58,6 +58,7 @@
         </div>
         <app-add-review
           [unitCode]="selectedUnitCode()!"
+          [editReview]="editingReview()"
           (reviewAdded)="onReviewAdded()"
           (cancel)="cancelAddReview()"
         />
@@ -91,6 +92,7 @@
             }
           </div>
           <div class="review-actions">
+            <button type="button" class="btn-text" (click)="startEditReview(review)">Edit</button>
             <button type="button" class="btn-text" (click)="viewUnit(review.unitCode)">View unit</button>
             <button type="button" class="btn-text danger" (click)="deleteReview(review)">Delete</button>
           </div>

--- a/frontend/src/app/components/my-reviews/my-reviews.component.ts
+++ b/frontend/src/app/components/my-reviews/my-reviews.component.ts
@@ -26,6 +26,7 @@ export class MyReviewsComponent implements OnInit {
   successMessage = signal<string | null>(null);
 
   showAddFlow = signal(false);
+  editingReview = signal<MyReview | null>(null);
   selectedUnitCode = signal<string | null>(null);
   selectedUnitName = signal<string | null>(null);
 
@@ -42,7 +43,7 @@ export class MyReviewsComponent implements OnInit {
       switchMap(query =>
         this.unitService.getUnits(0, 20, query || undefined, [], undefined, 'code')
       ),
-      map(page => page.content)
+      map(page => page.content.filter(unit => !this.hasReviewForUnit(unit.code)))
     );
   }
 
@@ -64,14 +65,23 @@ export class MyReviewsComponent implements OnInit {
 
   startAddReview() {
     this.showAddFlow.set(true);
+    this.editingReview.set(null);
     this.selectedUnitCode.set(null);
     this.selectedUnitName.set(null);
     this.searchQuery = '';
     this.searchSubject.next('');
   }
 
+  startEditReview(review: MyReview) {
+    this.showAddFlow.set(true);
+    this.editingReview.set(review);
+    this.selectedUnitCode.set(review.unitCode);
+    this.selectedUnitName.set(review.unitName);
+  }
+
   cancelAddReview() {
     this.showAddFlow.set(false);
+    this.editingReview.set(null);
     this.selectedUnitCode.set(null);
     this.selectedUnitName.set(null);
   }
@@ -81,12 +91,17 @@ export class MyReviewsComponent implements OnInit {
   }
 
   selectUnit(unit: UnitSummary) {
+    if (this.hasReviewForUnit(unit.code)) {
+      this.errorMessage.set('You have already reviewed this unit. Edit your existing review instead.');
+      return;
+    }
     this.selectedUnitCode.set(unit.code);
     this.selectedUnitName.set(unit.name);
+    this.errorMessage.set(null);
   }
 
   onReviewAdded() {
-    this.successMessage.set('Review submitted successfully.');
+    this.successMessage.set(this.editingReview() ? 'Review updated successfully.' : 'Review submitted successfully.');
     this.cancelAddReview();
     this.loadReviews();
   }
@@ -107,5 +122,9 @@ export class MyReviewsComponent implements OnInit {
 
   viewUnit(code: string) {
     this.router.navigate(['/units', code]);
+  }
+
+  private hasReviewForUnit(unitCode: string): boolean {
+    return this.reviews().some(review => review.unitCode === unitCode);
   }
 }

--- a/frontend/src/app/components/register/register.component.css
+++ b/frontend/src/app/components/register/register.component.css
@@ -63,6 +63,21 @@ input:focus {
   margin-top: 5px;
 }
 
+.optional {
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+.campaign-banner {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  padding: 12px;
+  border-left: 4px solid #2563eb;
+  margin-bottom: 20px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
 .btn-primary {
   width: 100%;
   background-color: var(--primary-color);

--- a/frontend/src/app/components/register/register.component.html
+++ b/frontend/src/app/components/register/register.component.html
@@ -19,6 +19,24 @@
       </div>
 
       <div class="form-group">
+        <label for="promoCode">Promo code <span class="optional">(optional)</span></label>
+        <input
+          type="text"
+          id="promoCode"
+          name="promoCode"
+          [(ngModel)]="promoCode"
+          (ngModelChange)="onPromoCodeChange()"
+          placeholder="e.g. CURTIN-JUL26"
+          autocomplete="off"
+        >
+        <div class="hint">Enter a promo code from a Discord post or outreach campaign to join a prize draw.</div>
+      </div>
+
+      @if (campaignMessage()) {
+        <div class="campaign-banner">{{ campaignMessage() }}</div>
+      }
+
+      <div class="form-group">
         <label for="password">Password</label>
         <input 
           type="password" 

--- a/frontend/src/app/components/register/register.component.ts
+++ b/frontend/src/app/components/register/register.component.ts
@@ -1,8 +1,12 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
+import { CampaignService } from '../../services/campaign.service';
+
+const CAMPAIGN_REF_KEY = 'campaign_ref';
+const CAMPAIGN_CODE_KEY = 'campaign_code';
 
 @Component({
   selector: 'app-register',
@@ -11,16 +15,44 @@ import { AuthService } from '../../services/auth.service';
   templateUrl: './register.component.html',
   styleUrl: './register.component.css'
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnInit {
   private authService = inject(AuthService);
+  private campaignService = inject(CampaignService);
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
 
   email = '';
   password = '';
   confirmPassword = '';
+  promoCode = '';
+  ref = '';
+  campaignMessage = signal<string | null>(null);
   errorMessage = signal<string | null>(null);
   successMessage = signal<string | null>(null);
   isLoading = signal(false);
+
+  ngOnInit() {
+    this.route.queryParamMap.subscribe(params => {
+      const refParam = params.get('ref') ?? sessionStorage.getItem(CAMPAIGN_REF_KEY) ?? '';
+      const codeParam = params.get('code') ?? sessionStorage.getItem(CAMPAIGN_CODE_KEY) ?? '';
+
+      if (params.get('ref')) {
+        sessionStorage.setItem(CAMPAIGN_REF_KEY, refParam);
+      }
+      if (params.get('code')) {
+        sessionStorage.setItem(CAMPAIGN_CODE_KEY, codeParam);
+      }
+
+      this.ref = refParam;
+      if (codeParam) {
+        this.promoCode = codeParam;
+      }
+
+      if (refParam || codeParam) {
+        this.validateCampaign(refParam, codeParam);
+      }
+    });
+  }
 
   onSubmit() {
     if (this.password !== this.confirmPassword) {
@@ -31,9 +63,17 @@ export class RegisterComponent {
     this.isLoading.set(true);
     this.errorMessage.set(null);
 
-    this.authService.register({ email: this.email, password: this.password }).subscribe({
+    this.authService.register({
+      email: this.email,
+      password: this.password,
+      ref: this.ref || undefined,
+      promoCode: this.promoCode || undefined
+    }).subscribe({
       next: (response) => {
         this.isLoading.set(false);
+        sessionStorage.removeItem(CAMPAIGN_REF_KEY);
+        sessionStorage.removeItem(CAMPAIGN_CODE_KEY);
+
         const message = response.verifiedStudent
           ? 'Registration successful! You are verified as a Curtin student.'
           : 'Registration successful! Verify your student email from your account to show the verified badge on reviews.';
@@ -43,6 +83,32 @@ export class RegisterComponent {
       error: (err) => {
         this.isLoading.set(false);
         this.errorMessage.set(err.error?.error || 'Registration failed. Please try again.');
+      }
+    });
+  }
+
+  onPromoCodeChange() {
+    if (this.ref || this.promoCode) {
+      this.validateCampaign(this.ref, this.promoCode);
+    } else {
+      this.campaignMessage.set(null);
+    }
+  }
+
+  private validateCampaign(ref: string, code: string) {
+    if (!ref && !code) {
+      return;
+    }
+
+    this.campaignService.validate(ref || undefined, code || undefined).subscribe({
+      next: (result) => {
+        if (result.valid) {
+          const prize = result.prizeDescription ? ` Prize: ${result.prizeDescription}.` : '';
+          this.campaignMessage.set(`You're signing up for ${result.campaignName}.${prize}`);
+          this.errorMessage.set(null);
+        } else {
+          this.campaignMessage.set(null);
+        }
       }
     });
   }

--- a/frontend/src/app/components/unit-detail/unit-detail.component.html
+++ b/frontend/src/app/components/unit-detail/unit-detail.component.html
@@ -147,14 +147,15 @@
         <button *ngIf="authService.isLoggedIn() && !showAddReviewForm()" 
                 (click)="toggleAddReviewForm()" 
                 class="btn btn-primary add-review-btn">
-          Add Review
+          {{ hasExistingReview() ? 'Edit your review' : 'Add Review' }}
         </button>
       </div>
 
       <!-- The Add Review Form (hidden by default) -->
       <app-add-review 
         *ngIf="showAddReviewForm()" 
-        [unitCode]="unit.code" 
+        [unitCode]="unit.code"
+        [editReview]="myReviewForUnit()"
         (reviewAdded)="onReviewAdded()"
         (cancel)="toggleAddReviewForm()">
       </app-add-review>

--- a/frontend/src/app/components/unit-detail/unit-detail.component.ts
+++ b/frontend/src/app/components/unit-detail/unit-detail.component.ts
@@ -3,8 +3,9 @@ import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { UnitService } from '../../services/unit.service';
 import { AuthService } from '../../services/auth.service';
+import { ReviewService } from '../../services/review.service';
 import { SeoService } from '../../services/seo.service';
-import { UnitDetails } from '../../models/unit.model';
+import { MyReview, UnitDetails } from '../../models/unit.model';
 import { Observable, switchMap, map, of, tap } from 'rxjs';
 import { AddReviewComponent } from '../add-review/add-review.component';
 
@@ -22,26 +23,24 @@ import { AddReviewComponent } from '../add-review/add-review.component';
 export class UnitDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private unitService = inject(UnitService);
+  private reviewService = inject(ReviewService);
   private seoService = inject(SeoService);
   authService = inject(AuthService);
 
-  // This will store all the unit information once it's fetched
   unit$: Observable<UnitDetails> | undefined;
-  
-  // Track if we should show the add review form
   showAddReviewForm = signal(false);
+  myReviewForUnit = signal<MyReview | null>(null);
 
   ngOnInit(): void {
     this.loadUnit();
   }
 
   loadUnit() {
-    // 1. Listen to changes in the URL parameters (like /units/COMP1000)
-    // 2. Use 'switchMap' to switch from the URL stream to the API data stream
     this.unit$ = this.route.paramMap.pipe(
       switchMap(params => {
         const code = params.get('code') || '';
         if (!code) return of(null as any);
+        this.loadMyReviewForUnit(code);
         return this.unitService.getUnitByCode(code);
       }),
       map((unit: UnitDetails) => {
@@ -66,7 +65,27 @@ export class UnitDetailComponent implements OnInit {
 
   onReviewAdded() {
     this.showAddReviewForm.set(false);
+    const code = this.route.snapshot.paramMap.get('code');
+    if (code) {
+      this.loadMyReviewForUnit(code);
+    }
     this.loadUnit();
+  }
+
+  hasExistingReview(): boolean {
+    return !!this.myReviewForUnit();
+  }
+
+  private loadMyReviewForUnit(unitCode: string) {
+    if (!this.authService.isLoggedIn()) {
+      this.myReviewForUnit.set(null);
+      return;
+    }
+
+    this.reviewService.getMyReviewForUnit(unitCode).subscribe({
+      next: (review) => this.myReviewForUnit.set(review),
+      error: () => this.myReviewForUnit.set(null)
+    });
   }
 
   getStarArray(rating: number): string[] {

--- a/frontend/src/app/models/unit.model.ts
+++ b/frontend/src/app/models/unit.model.ts
@@ -51,8 +51,13 @@ export interface MyReview {
   unitCode: string;
   unitName: string;
   rating: number;
+  finalGrade?: number | null;
   reviewText: string;
   semesterTaken: string;
+  professor?: string;
+  workload?: number;
+  hasExam?: boolean;
+  wouldTakeAgain?: boolean;
   createdAt: string;
 }
 

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -30,12 +30,21 @@ export interface JwtResponse {
   verifiedStudent: boolean;
 }
 
+export interface CampaignProgress {
+  qualifyingReviews: number;
+  requiredReviews: number;
+  entriesEarned: number;
+  maxEntries: number;
+  requireVerifiedStudent: boolean;
+}
+
 export interface AccountStatus {
   email: string;
   verifiedStudent: boolean;
   campaignName: string | null;
   campaignPrizeDescription: string | null;
   campaignEndsAt: string | null;
+  campaignProgress: CampaignProgress | null;
   campaignEntries: CampaignEntrySummary[];
 }
 

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -11,6 +11,8 @@ export interface LoginRequest {
 export interface RegisterRequest {
   email: string;
   password?: string;
+  ref?: string;
+  promoCode?: string;
 }
 
 export interface VerifyStudentRequest {
@@ -31,6 +33,17 @@ export interface JwtResponse {
 export interface AccountStatus {
   email: string;
   verifiedStudent: boolean;
+  campaignName: string | null;
+  campaignPrizeDescription: string | null;
+  campaignEndsAt: string | null;
+  campaignEntries: CampaignEntrySummary[];
+}
+
+export interface CampaignEntrySummary {
+  entryToken: string;
+  campaignName: string;
+  unitCode: string;
+  createdAt: string;
 }
 
 @Injectable({

--- a/frontend/src/app/services/campaign.service.ts
+++ b/frontend/src/app/services/campaign.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface CampaignValidation {
+  valid: boolean;
+  message: string;
+  campaignName: string | null;
+  prizeDescription: string | null;
+  endsAt: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CampaignService {
+  private http = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/campaigns`;
+
+  validate(ref?: string, code?: string): Observable<CampaignValidation> {
+    const params: Record<string, string> = {};
+    if (ref?.trim()) {
+      params['ref'] = ref.trim();
+    }
+    if (code?.trim()) {
+      params['code'] = code.trim();
+    }
+    return this.http.get<CampaignValidation>(`${this.apiUrl}/validate`, { params });
+  }
+}

--- a/frontend/src/app/services/review.service.ts
+++ b/frontend/src/app/services/review.service.ts
@@ -1,13 +1,23 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import { MyReview } from '../models/unit.model';
+
+export interface CampaignProgress {
+  qualifyingReviews: number;
+  requiredReviews: number;
+  entriesEarned: number;
+  maxEntries: number;
+  requireVerifiedStudent: boolean;
+}
 
 export interface CreateReviewResponse {
   review: unknown;
   campaignEntryToken: string | null;
   campaignName: string | null;
+  campaignProgress: CampaignProgress | null;
 }
 
 @Injectable({
@@ -21,8 +31,20 @@ export class ReviewService {
     return this.http.get<MyReview[]>(`${this.apiUrl}/me`);
   }
 
+  getMyReviewForUnit(unitCode: string): Observable<MyReview | null> {
+    return this.http.get<MyReview>(`${this.apiUrl}/me/unit/${encodeURIComponent(unitCode)}`, {
+      observe: 'response'
+    }).pipe(
+      map(response => (response.status === 204 || !response.body) ? null : response.body)
+    );
+  }
+
   createReview(review: unknown): Observable<CreateReviewResponse> {
     return this.http.post<CreateReviewResponse>(this.apiUrl, review);
+  }
+
+  updateReview(id: string, review: unknown): Observable<CreateReviewResponse> {
+    return this.http.patch<CreateReviewResponse>(`${this.apiUrl}/${id}`, review);
   }
 
   deleteReview(id: string): Observable<void> {

--- a/frontend/src/app/services/review.service.ts
+++ b/frontend/src/app/services/review.service.ts
@@ -4,6 +4,12 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { MyReview } from '../models/unit.model';
 
+export interface CreateReviewResponse {
+  review: unknown;
+  campaignEntryToken: string | null;
+  campaignName: string | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -15,8 +21,8 @@ export class ReviewService {
     return this.http.get<MyReview[]>(`${this.apiUrl}/me`);
   }
 
-  createReview(review: unknown): Observable<unknown> {
-    return this.http.post(this.apiUrl, review);
+  createReview(review: unknown): Observable<CreateReviewResponse> {
+    return this.http.post<CreateReviewResponse>(this.apiUrl, review);
   }
 
   deleteReview(id: string): Observable<void> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an outreach campaign system for Discord and other promotions:

- **Referral links** — `/register?ref=<slug>&code=<code>` attributes signups to a campaign
- **Promo codes** — optional code field on registration
- **Draw entry tokens** — unique `CH-XXXXXXXX` tokens when campaign criteria are met
- **Configurable eligibility** — per-campaign rules for verification, review count, and review length
- **One review per unit** — enforced globally; users edit existing reviews instead of posting duplicates

## Campaign constraints (admin-configurable)

| Setting | Purpose | Default |
|---------|---------|---------|
| **Require verified student** | Off for alumni / non-student campaigns | On |
| **Required reviews for entry** | e.g. 4 = must review 4 different units for one draw entry | 1 |
| **Min review length** | Minimum characters for a qualifying review | 50 |
| **Max draw entries per user** | Cap on tokens earned | 1 |
| **Campaign dates** | Reviews must fall within window to qualify | — |

### Example: alumni semester campaign

- Require verified student: **off**
- Required reviews for entry: **4**
- Max draw entries per user: **1**
- Min review length: **50**

User leaves 4 reviews on 4 different units → receives one `CH-` entry token.

### Example: standard student promo

- Require verified student: **on**
- Required reviews for entry: **1**
- Max draw entries per user: **5**

One token per qualifying review, up to 5.

## One review per unit

- Database unique constraint on `(user_id, unit_id)`
- Attempting a second review returns a clear error
- **Edit** available from My Reviews and unit detail pages (`PATCH /reviews/{id}`)
- Editing can upgrade a review to qualifying length and trigger campaign progress / entry

## Frontend

- Register: `?ref=` + promo code field
- Account: campaign progress (e.g. "3/4 qualifying reviews — 1 more needed")
- Add/edit review: progress messaging and entry token on success
- Admin → Campaigns: create, copy link, export entries CSV

## API highlights

- `GET /campaigns/validate`
- `POST /auth/register` with `ref`, `promoCode`
- `GET /auth/me` with `campaignProgress`
- `GET /reviews/me/unit/{code}` — check existing review
- `PATCH /reviews/{id}` — edit review
- Admin campaign CRUD + entry export
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2551-ccb3-7410-b0ff-6205d9a8f171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2551-ccb3-7410-b0ff-6205d9a8f171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

