### PR TITLE
chore(analytics): add sitewide Google tag

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -11,6 +11,15 @@
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   <link rel="icon" type="image/png" href="favicon.png">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3H2M1W3GSR"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-3H2M1W3GSR');
+  </script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- add the Google Analytics `gtag.js` snippet to the Angular `index.html` shell
- ensure the tracking tag loads on every route because it is injected from the global site template
- keep the change scoped to a single frontend entrypoint file
## Test plan
- [x] Confirm the Google tag snippet is present in `frontend/src/index.html`
- [ ] Open the deployed site and verify the script appears in the page `<head>`
- [ ] Confirm page views are received in Google Analytics