### PR TITLE
chore(analytics): gate Google tag to production builds

### DIFF
--- a/frontend/src/app/google-analytics.ts
+++ b/frontend/src/app/google-analytics.ts
@@ -1,0 +1,29 @@
+import { environment } from '../environments/environment';
+
+const GA_MEASUREMENT_ID = 'G-3H2M1W3GSR';
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+/** Loads Google Analytics only on prod builds (same gate as SEO indexing). */
+export function initGoogleAnalytics(): void {
+  if (!environment.seoEnabled) {
+    return;
+  }
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function gtag(...args: unknown[]) {
+    window.dataLayer.push(args);
+  };
+  window.gtag('js', new Date());
+  window.gtag('config', GA_MEASUREMENT_ID);
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+  document.head.appendChild(script);
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -11,15 +11,6 @@
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   <link rel="icon" type="image/png" href="favicon.png">
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3H2M1W3GSR"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-3H2M1W3GSR');
-  </script>
 </head>
 <body>
   <app-root></app-root>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,9 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
+import { initGoogleAnalytics } from './app/google-analytics';
+
+initGoogleAnalytics();
 
 bootstrapApplication(App, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
Load gtag from app startup only when seoEnabled is true so dev, preview, and local traffic are excluded from analytics.