### PR TITLE
feat(seo): implement structured data, metadata, and indexing improvem…

### DIFF
--- a/backend/src/main/java/com/curtinhonestly/backend/dto/ReviewDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/ReviewDTO.java
@@ -2,6 +2,8 @@ package com.curtinhonestly.backend.dto;
 
 import lombok.Data;
 
+import java.time.Instant;
+
 @Data
 public class ReviewDTO {
 
@@ -16,4 +18,5 @@ public class ReviewDTO {
     private boolean wouldTakeAgain;
 
     private boolean reviewerVerified;
+    private Instant createdAt;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/UnitSummaryDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/UnitSummaryDTO.java
@@ -2,6 +2,7 @@ package com.curtinhonestly.backend.dto;
 
 import lombok.Data;
 
+import java.time.Instant;
 
 @Data
 public class UnitSummaryDTO {
@@ -14,4 +15,7 @@ public class UnitSummaryDTO {
     private int numberOfReviews;
     private double averageRating;
     private double wouldTakeAgainRatio;
+
+    // Null when no reviews exist; used for sitemap lastmod
+    private Instant latestReviewAt;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
@@ -21,6 +21,7 @@ public class ReviewMapper {
         dto.setWorkload(review.getWorkload());
         dto.setHasExam(review.isHasExam());
         dto.setWouldTakeAgain(review.isWouldTakeAgain());
+        dto.setCreatedAt(review.getCreatedAt());
 
         if (review.getUser() != null) {
             dto.setReviewerVerified(review.getUser().isVerifiedStudent());

--- a/backend/src/main/java/com/curtinhonestly/backend/mapper/UnitMapper.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/mapper/UnitMapper.java
@@ -3,7 +3,9 @@ package com.curtinhonestly.backend.mapper;
 import com.curtinhonestly.backend.domain.*;
 import com.curtinhonestly.backend.dto.*;
 
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -26,6 +28,14 @@ public class UnitMapper {
         dto.setNumberOfReviews(reviews.size());
         dto.setAverageRating(calculateAverageRating(reviews));
         dto.setWouldTakeAgainRatio(calculateWouldTakeAgainRatio(reviews));
+
+        Instant latestReviewAt = reviews.stream()
+                .map(Review::getCreatedAt)
+                .filter(Objects::nonNull)
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+        dto.setLatestReviewAt(latestReviewAt);
+
         return dto;
     }
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -43,8 +43,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "6kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all"

--- a/frontend/scripts/fetch-unit-codes.js
+++ b/frontend/scripts/fetch-unit-codes.js
@@ -7,11 +7,13 @@ const path = require('path');
 const { resolveSeoBuildConfig } = require('./seo-build-config');
 
 const outputPath = path.resolve(__dirname, '../src/generated/unit-codes.json');
+const sitemapMetaPath = path.resolve(__dirname, '../src/generated/unit-sitemap-meta.json');
 const PAGE_SIZE = 500;
 const isCi = process.env.GITHUB_ACTIONS === 'true';
 
-async function fetchAllUnitCodes(apiUrl) {
+async function fetchAllUnits(apiUrl) {
   const codes = [];
+  const sitemapMeta = [];
   let page = 0;
   let totalPages = 1;
 
@@ -29,6 +31,10 @@ async function fetchAllUnitCodes(apiUrl) {
     for (const unit of content) {
       if (unit.code) {
         codes.push(unit.code);
+        sitemapMeta.push({
+          code: unit.code,
+          lastmod: unit.latestReviewAt ? unit.latestReviewAt.slice(0, 10) : null,
+        });
       }
     }
 
@@ -37,30 +43,33 @@ async function fetchAllUnitCodes(apiUrl) {
     console.log(`Fetched page ${page}/${totalPages} (${codes.length} codes so far)`);
   }
 
-  return codes;
+  return { codes, sitemapMeta };
 }
 
-function writeEmptyCodes(reason) {
+function writeEmptyOutputs(reason) {
   console.log(reason);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, '[]\n');
+  fs.writeFileSync(sitemapMetaPath, '[]\n');
 }
 
 async function main() {
   const { apiUrl, seoEnabled } = resolveSeoBuildConfig();
 
   if (!seoEnabled) {
-    writeEmptyCodes('SEO disabled for this build — skipping unit code fetch (no backend load).');
+    writeEmptyOutputs('SEO disabled for this build — skipping unit code fetch (no backend load).');
     return;
   }
 
   console.log(`SEO enabled — fetching unit codes from ${apiUrl} ...`);
 
   try {
-    const codes = await fetchAllUnitCodes(apiUrl);
+    const { codes, sitemapMeta } = await fetchAllUnits(apiUrl);
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
     fs.writeFileSync(outputPath, JSON.stringify(codes, null, 2));
+    fs.writeFileSync(sitemapMetaPath, JSON.stringify(sitemapMeta, null, 2));
     console.log(`Wrote ${codes.length} unit codes to ${outputPath}`);
+    console.log(`Wrote sitemap metadata to ${sitemapMetaPath}`);
   } catch (error) {
     console.error('Failed to fetch unit codes:', error.message);
 
@@ -68,7 +77,7 @@ async function main() {
       process.exit(1);
     }
 
-    writeEmptyCodes('Non-CI build: writing empty unit-codes.json after fetch failure.');
+    writeEmptyOutputs('Non-CI build: writing empty outputs after fetch failure.');
   }
 }
 

--- a/frontend/scripts/generate-seo-assets.js
+++ b/frontend/scripts/generate-seo-assets.js
@@ -7,6 +7,7 @@ const path = require('path');
 const { resolveSeoBuildConfig } = require('./seo-build-config');
 
 const unitCodesPath = path.resolve(__dirname, '../src/generated/unit-codes.json');
+const sitemapMetaPath = path.resolve(__dirname, '../src/generated/unit-sitemap-meta.json');
 const publicDir = path.resolve(__dirname, '../public');
 
 const { siteUrl, seoEnabled } = resolveSeoBuildConfig();
@@ -15,6 +16,13 @@ let unitCodes = [];
 if (fs.existsSync(unitCodesPath)) {
   unitCodes = JSON.parse(fs.readFileSync(unitCodesPath, 'utf8'));
 }
+
+let sitemapMeta = [];
+if (fs.existsSync(sitemapMetaPath)) {
+  sitemapMeta = JSON.parse(fs.readFileSync(sitemapMetaPath, 'utf8'));
+}
+
+const sitemapMetaByCode = Object.fromEntries(sitemapMeta.map((e) => [e.code, e]));
 
 fs.mkdirSync(publicDir, { recursive: true });
 
@@ -47,14 +55,15 @@ const urlEntries = [
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>`,
-  ...unitCodes.map(
-    (code) => `  <url>
+  ...unitCodes.map((code) => {
+    const lastmod = sitemapMetaByCode[code]?.lastmod || today;
+    return `  <url>
     <loc>${siteUrl}/units/${encodeURIComponent(code)}</loc>
-    <lastmod>${today}</lastmod>
+    <lastmod>${lastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
-  </url>`
-  ),
+  </url>`;
+  }),
 ];
 
 const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/frontend/src/app/components/account/account.component.ts
+++ b/frontend/src/app/components/account/account.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
+import { SeoService } from '../../services/seo.service';
 
 @Component({
   selector: 'app-account',
@@ -14,6 +15,7 @@ import { AuthService } from '../../services/auth.service';
 export class AccountComponent implements OnInit {
   protected authService = inject(AuthService);
   private router = inject(Router);
+  private seoService = inject(SeoService);
 
   newEmail = '';
   emailPassword = '';
@@ -26,6 +28,8 @@ export class AccountComponent implements OnInit {
   isLoading = signal(false);
 
   ngOnInit() {
+    this.seoService.noIndex('Account | CurtinHonestly');
+
     if (!this.authService.isLoggedIn()) {
       this.router.navigate(['/login']);
       return;

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -1,8 +1,9 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
+import { SeoService } from '../../services/seo.service';
 
 @Component({
   selector: 'app-login',
@@ -11,9 +12,14 @@ import { AuthService } from '../../services/auth.service';
   templateUrl: './login.component.html',
   styleUrl: './login.component.css'
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
   private authService = inject(AuthService);
   private router = inject(Router);
+  private seoService = inject(SeoService);
+
+  ngOnInit(): void {
+    this.seoService.noIndex('Log In | CurtinHonestly');
+  }
 
   email = '';
   password = '';

--- a/frontend/src/app/components/my-reviews/my-reviews.component.ts
+++ b/frontend/src/app/components/my-reviews/my-reviews.component.ts
@@ -5,6 +5,7 @@ import { Router, RouterLink } from '@angular/router';
 import { BehaviorSubject, debounceTime, distinctUntilChanged, map, Observable, switchMap } from 'rxjs';
 import { ReviewService } from '../../services/review.service';
 import { UnitService } from '../../services/unit.service';
+import { SeoService } from '../../services/seo.service';
 import { MyReview, UnitSummary } from '../../models/unit.model';
 import { AddReviewComponent } from '../add-review/add-review.component';
 
@@ -19,6 +20,7 @@ export class MyReviewsComponent implements OnInit {
   private reviewService = inject(ReviewService);
   private unitService = inject(UnitService);
   private router = inject(Router);
+  private seoService = inject(SeoService);
 
   reviews = signal<MyReview[]>([]);
   isLoading = signal(true);
@@ -34,6 +36,7 @@ export class MyReviewsComponent implements OnInit {
   searchResults$: Observable<UnitSummary[]> | undefined;
 
   ngOnInit() {
+    this.seoService.noIndex('My Reviews | CurtinHonestly');
     this.loadReviews();
 
     this.searchResults$ = this.searchSubject.pipe(

--- a/frontend/src/app/components/register/register.component.ts
+++ b/frontend/src/app/components/register/register.component.ts
@@ -1,8 +1,9 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
+import { SeoService } from '../../services/seo.service';
 
 @Component({
   selector: 'app-register',
@@ -11,9 +12,14 @@ import { AuthService } from '../../services/auth.service';
   templateUrl: './register.component.html',
   styleUrl: './register.component.css'
 })
-export class RegisterComponent {
+export class RegisterComponent implements OnInit {
   private authService = inject(AuthService);
   private router = inject(Router);
+  private seoService = inject(SeoService);
+
+  ngOnInit(): void {
+    this.seoService.noIndex('Register | CurtinHonestly');
+  }
 
   email = '';
   password = '';

--- a/frontend/src/app/components/unit-detail/unit-detail.component.css
+++ b/frontend/src/app/components/unit-detail/unit-detail.component.css
@@ -4,6 +4,35 @@
   padding: 40px 20px;
 }
 
+/* Breadcrumb */
+.breadcrumb {
+  margin-bottom: 16px;
+}
+
+.breadcrumb ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.breadcrumb li + li::before {
+  content: '›';
+}
+
+.breadcrumb a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
 /* Header Styling */
 .detail-header {
   margin-bottom: 40px;

--- a/frontend/src/app/components/unit-detail/unit-detail.component.html
+++ b/frontend/src/app/components/unit-detail/unit-detail.component.html
@@ -1,4 +1,12 @@
 <div class="detail-container" *ngIf="unit$ | async as unit; else loading">
+  <!-- Breadcrumb navigation -->
+  <nav class="breadcrumb" aria-label="Breadcrumb">
+    <ol>
+      <li><a routerLink="/">Home</a></li>
+      <li aria-current="page">{{ unit.code }}</li>
+    </ol>
+  </nav>
+
   <!-- Top section with back button and unit header -->
   <header class="detail-header">
     <a routerLink="/" class="back-link">&larr; Back to all units</a>
@@ -14,13 +22,13 @@
         </p>
         
         <div class="header-actions" *ngIf="unit.unitLink">
-          <a [href]="unit.unitLink" target="_blank" class="btn btn-handbook">
+          <a [href]="unit.unitLink" target="_blank" rel="noopener noreferrer" class="btn btn-handbook">
             View in Curtin Handbook
           </a>
         </div>
       </div>
       
-      <div class="header-right">
+      <div class="header-right" *ngIf="unit.numberOfReviews > 0">
         <div class="big-rating">
           <span class="big-num">{{ unit.averageRating | number:'1.1-1' }}</span>
           <div class="big-stars-container">
@@ -39,7 +47,7 @@
   </header>
 
   <!-- Summary Cards Section -->
-  <section class="summary-stats">
+  <section class="summary-stats" *ngIf="unit.numberOfReviews > 0">
     <div class="stat-card">
       <span class="stat-title">Workload</span>
       <span class="stat-value">{{ unit.averageWorkload | number:'1.1-1' }}/10</span>
@@ -87,7 +95,7 @@
           </div>
           <div class="info-item full-width" *ngIf="unit.unitLink">
             <span class="label">Handbook</span>
-            <a [href]="unit.unitLink" target="_blank" class="handbook-link">
+            <a [href]="unit.unitLink" target="_blank" rel="noopener noreferrer" class="handbook-link">
               View Official Handbook Page &rarr;
             </a>
           </div>
@@ -171,12 +179,11 @@
         <div class="review-header">
           <div class="user-info">
             <span class="user-name">
-              Anonymous
-              <span *ngIf="review.reviewerVerified" class="verified-badge" title="Verified Curtin student">
+              {{ reviewAuthorName(review.reviewerVerified) }}
+              <span *ngIf="review.reviewerVerified" class="verified-badge" title="Verified Curtin student" aria-label="Verified Curtin student">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
                   <path fill="currentColor" d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm-1 14.59l-4.29-4.3 1.42-1.41L11 12.17l5.88-5.88 1.41 1.41L11 15.59z"/>
                 </svg>
-                Verified student
               </span>
             </span>
             <span class="review-meta">{{ review.semesterTaken }} • Prof. {{ review.professor }}</span>

--- a/frontend/src/app/components/unit-detail/unit-detail.component.ts
+++ b/frontend/src/app/components/unit-detail/unit-detail.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import { UnitService } from '../../services/unit.service';
 import { AuthService } from '../../services/auth.service';
 import { SeoService } from '../../services/seo.service';
+import { reviewAuthorName } from '../../utils/unit-seo.utils';
 import { UnitDetails } from '../../models/unit.model';
 import { Observable, switchMap, map, of, tap } from 'rxjs';
 import { AddReviewComponent } from '../add-review/add-review.component';
@@ -24,6 +25,7 @@ export class UnitDetailComponent implements OnInit {
   private unitService = inject(UnitService);
   private seoService = inject(SeoService);
   authService = inject(AuthService);
+  reviewAuthorName = reviewAuthorName;
 
   // This will store all the unit information once it's fetched
   unit$: Observable<UnitDetails> | undefined;

--- a/frontend/src/app/models/unit.model.ts
+++ b/frontend/src/app/models/unit.model.ts
@@ -44,6 +44,7 @@ export interface Review {
   hasExam: boolean;
   wouldTakeAgain: boolean;
   reviewerVerified: boolean;
+  createdAt?: string;
 }
 
 export interface MyReview {

--- a/frontend/src/app/services/seo.service.ts
+++ b/frontend/src/app/services/seo.service.ts
@@ -51,7 +51,7 @@ export class SeoService {
       return;
     }
 
-    const title = unitPageTitle(unit.code, unit.name);
+    const title = unitPageTitle(unit.code, unit.name, unit.numberOfReviews);
     const description = unitPageDescription(unit);
     const url = `${this.siteUrl}${unitPagePath(unit.code)}`;
 
@@ -67,11 +67,16 @@ export class SeoService {
     this.setJsonLd(buildUnitJsonLd(unit, this.siteUrl));
   }
 
-  private applyDevNoIndex(pageTitle: string): void {
+  /** Call from any route that must never be indexed (auth, account pages). */
+  noIndex(pageTitle: string): void {
     this.title.setTitle(pageTitle);
     this.meta.updateTag({ name: 'robots', content: 'noindex, nofollow' });
     this.removeCanonical();
     this.removeJsonLd();
+  }
+
+  private applyDevNoIndex(pageTitle: string): void {
+    this.noIndex(pageTitle);
   }
 
   private setDescription(description: string): void {
@@ -111,6 +116,7 @@ export class SeoService {
     this.meta.updateTag({ property: 'og:description', content: description });
     this.meta.updateTag({ property: 'og:url', content: url });
     this.meta.updateTag({ property: 'og:type', content: type });
+    this.meta.updateTag({ property: 'og:locale', content: 'en_AU' });
     this.meta.updateTag({ property: 'og:site_name', content: 'CurtinHonestly' });
     this.meta.updateTag({ property: 'og:image', content: image });
     this.meta.updateTag({ name: 'twitter:card', content: 'summary' });

--- a/frontend/src/app/utils/unit-seo.utils.spec.ts
+++ b/frontend/src/app/utils/unit-seo.utils.spec.ts
@@ -1,0 +1,512 @@
+import { describe, expect, it } from 'vitest';
+import { UnitDetails } from '../models/unit.model';
+import {
+  buildHomeJsonLd,
+  buildSitewideJsonLd,
+  buildUnitJsonLd,
+  reviewAuthorName,
+  safeHttpsUrl,
+  unitPageTitle,
+} from './unit-seo.utils';
+
+const SITE_URL = 'https://curtinhonestly.com';
+
+function baseUnit(overrides: Partial<UnitDetails> = {}): UnitDetails {
+  return {
+    code: 'ISYS1000',
+    name: 'Introduction to Business Information Systems',
+    description: 'An introductory IS unit.',
+    unitLink: 'https://handbook.curtin.edu.au/units/isys1000',
+    faculty: 'Business and Law',
+    level: 'UNDERGRADUATE',
+    area: '',
+    fieldOfEducation: '',
+    credits: 25,
+    contactHours: 3,
+    resultType: 'Grade',
+    tuitionPatterns: [],
+    prerequisiteGroups: [],
+    numberOfReviews: 0,
+    averageRating: 0,
+    averageWorkload: 0,
+    averageFinalGrade: 0,
+    wouldTakeAgainRatio: 0,
+    reviews: [],
+    ...overrides,
+  };
+}
+
+function getCourseNode(result: ReturnType<typeof buildUnitJsonLd>): Record<string, unknown> {
+  const graph = result['@graph'] as Record<string, unknown>[];
+  return graph.find((node) => node['@type'] === 'Course') as Record<string, unknown>;
+}
+
+function getBreadcrumbNode(result: ReturnType<typeof buildUnitJsonLd>): Record<string, unknown> {
+  const graph = result['@graph'] as Record<string, unknown>[];
+  return graph.find((node) => node['@type'] === 'BreadcrumbList') as Record<string, unknown>;
+}
+
+// ─── Item 1: review count in title tag ───────────────────────────────────────
+
+describe('unitPageTitle', () => {
+  it('includes unit name and review count when reviews exist', () => {
+    expect(unitPageTitle('ISYS1000', 'Introduction to BIS', 12)).toBe(
+      'ISYS1000 Introduction to BIS — 12 Reviews | CurtinHonestly'
+    );
+  });
+
+  it('uses code and name without review count when no reviews', () => {
+    expect(unitPageTitle('ISYS1000', 'Introduction to BIS', 0)).toBe(
+      'ISYS1000 Introduction to BIS | CurtinHonestly'
+    );
+  });
+
+  it('defaults to no-review format when numberOfReviews is omitted', () => {
+    expect(unitPageTitle('ISYS1000', 'Introduction to BIS')).toBe(
+      'ISYS1000 Introduction to BIS | CurtinHonestly'
+    );
+  });
+});
+
+// ─── Phase 1: review snippet gating ──────────────────────────────────────────
+
+describe('buildUnitJsonLd', () => {
+  it('omits aggregateRating and review when there are no reviews', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit(), SITE_URL));
+
+    expect(course['courseCode']).toBe('ISYS1000');
+    expect(course['aggregateRating']).toBeUndefined();
+    expect(course['review']).toBeUndefined();
+  });
+
+  it('includes aggregateRating and review array when reviews exist', () => {
+    const unit = baseUnit({
+      numberOfReviews: 2,
+      averageRating: 4.5,
+      reviews: [
+        {
+          rating: 5,
+          reviewText: 'Great unit with practical assignments.',
+          semesterTaken: 'Sem 1 2025',
+          professor: 'Smith',
+          workload: 6,
+          hasExam: true,
+          wouldTakeAgain: true,
+          reviewerVerified: true,
+          createdAt: '2025-06-01T10:00:00Z',
+        },
+        {
+          rating: 4,
+          reviewText: 'Challenging but fair.',
+          semesterTaken: 'Sem 2 2024',
+          professor: 'Jones',
+          workload: 7,
+          hasExam: false,
+          wouldTakeAgain: true,
+          reviewerVerified: false,
+          createdAt: '2024-11-15T08:30:00Z',
+        },
+      ],
+    });
+
+    const course = getCourseNode(buildUnitJsonLd(unit, SITE_URL));
+    const aggregateRating = course['aggregateRating'] as Record<string, unknown>;
+    const reviews = course['review'] as Record<string, unknown>[];
+
+    expect(aggregateRating).toEqual({
+      '@type': 'AggregateRating',
+      ratingValue: '4.5',
+      reviewCount: 2,
+      bestRating: '5',
+      worstRating: '1',
+    });
+    expect(reviews).toHaveLength(2);
+    expect(reviews[0]).toMatchObject({
+      '@type': 'Review',
+      author: { '@type': 'Person', name: reviewAuthorName(true) },
+      datePublished: '2025-06-01T10:00:00Z',
+      reviewBody: 'Great unit with practical assignments.',
+      reviewRating: {
+        '@type': 'Rating',
+        ratingValue: '5',
+        bestRating: '5',
+        worstRating: '1',
+      },
+    });
+  });
+
+  it('includes aggregateRating even when average rating is zero', () => {
+    const unit = baseUnit({
+      numberOfReviews: 1,
+      averageRating: 0,
+      reviews: [
+        {
+          rating: 0,
+          reviewText: 'Very difficult.',
+          semesterTaken: 'Sem 1 2025',
+          professor: 'Smith',
+          workload: 9,
+          hasExam: true,
+          wouldTakeAgain: false,
+          reviewerVerified: true,
+          createdAt: '2025-03-01T12:00:00Z',
+        },
+      ],
+    });
+
+    const course = getCourseNode(buildUnitJsonLd(unit, SITE_URL));
+    const aggregateRating = course['aggregateRating'] as Record<string, unknown>;
+
+    expect(aggregateRating['ratingValue']).toBe('0.0');
+    expect(aggregateRating['reviewCount']).toBe(1);
+  });
+
+  it('excludes reviews with empty text from the review array', () => {
+    const unit = baseUnit({
+      numberOfReviews: 2,
+      averageRating: 3,
+      reviews: [
+        {
+          rating: 3,
+          reviewText: '   ',
+          semesterTaken: 'Sem 1 2025',
+          professor: 'Smith',
+          workload: 5,
+          hasExam: false,
+          wouldTakeAgain: false,
+          reviewerVerified: false,
+        },
+        {
+          rating: 4,
+          reviewText: 'Solid overview.',
+          semesterTaken: 'Sem 2 2024',
+          professor: 'Jones',
+          workload: 4,
+          hasExam: true,
+          wouldTakeAgain: true,
+          reviewerVerified: true,
+          createdAt: '2024-12-01T09:00:00Z',
+        },
+      ],
+    });
+
+    const course = getCourseNode(buildUnitJsonLd(unit, SITE_URL));
+    const reviews = course['review'] as Record<string, unknown>[];
+
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]['reviewBody']).toBe('Solid overview.');
+    expect((reviews[0]['author'] as Record<string, unknown>)['name']).toBe(reviewAuthorName(true));
+  });
+
+  it('uses Student as author name for unverified reviews', () => {
+    const unit = baseUnit({
+      numberOfReviews: 1,
+      averageRating: 3,
+      reviews: [
+        {
+          rating: 3,
+          reviewText: 'Decent unit.',
+          semesterTaken: 'Sem 1 2025',
+          professor: 'Smith',
+          workload: 5,
+          hasExam: false,
+          wouldTakeAgain: false,
+          reviewerVerified: false,
+          createdAt: '2025-01-01T10:00:00Z',
+        },
+      ],
+    });
+
+    const course = getCourseNode(buildUnitJsonLd(unit, SITE_URL));
+    const reviews = course['review'] as Record<string, unknown>[];
+
+    expect((reviews[0]['author'] as Record<string, unknown>)['name']).toBe('Student');
+  });
+});
+
+// ─── Phase 2: course enrichment ──────────────────────────────────────────────
+
+describe('buildUnitJsonLd — Phase 2 course metadata', () => {
+  it('includes @id on Course and BreadcrumbList with stable URL-based IDs', () => {
+    const result = buildUnitJsonLd(baseUnit(), SITE_URL);
+    const course = getCourseNode(result);
+    const breadcrumb = getBreadcrumbNode(result);
+
+    expect(course['@id']).toBe('https://curtinhonestly.com/units/ISYS1000#course');
+    expect(breadcrumb['@id']).toBe('https://curtinhonestly.com/units/ISYS1000#breadcrumb');
+  });
+
+  it('includes sameAs when unitLink is a valid https URL', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit(), SITE_URL));
+    expect(course['sameAs']).toBe('https://handbook.curtin.edu.au/units/isys1000');
+  });
+
+  it('omits sameAs when unitLink is not https', () => {
+    const course = getCourseNode(
+      buildUnitJsonLd(baseUnit({ unitLink: 'http://handbook.curtin.edu.au/units/isys1000' }), SITE_URL)
+    );
+    expect(course['sameAs']).toBeUndefined();
+  });
+
+  it('omits sameAs when unitLink is empty', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit({ unitLink: '' }), SITE_URL));
+    expect(course['sameAs']).toBeUndefined();
+  });
+
+  it('includes about when area is set', () => {
+    const course = getCourseNode(
+      buildUnitJsonLd(baseUnit({ area: 'Business Information Systems' }), SITE_URL)
+    );
+    expect(course['about']).toBe('Business Information Systems');
+  });
+
+  it('omits about when area is empty', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit({ area: '' }), SITE_URL));
+    expect(course['about']).toBeUndefined();
+  });
+
+  it('includes educationalCredentialAwarded when credits > 0', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit({ credits: 25 }), SITE_URL));
+    expect(course['educationalCredentialAwarded']).toBe('25 credit points');
+  });
+
+  it('omits educationalCredentialAwarded when credits is 0', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit({ credits: 0 }), SITE_URL));
+    expect(course['educationalCredentialAwarded']).toBeUndefined();
+  });
+
+  it('uses full description without truncation in JSON-LD', () => {
+    const longDesc = 'A '.repeat(200).trim();
+    const course = getCourseNode(buildUnitJsonLd(baseUnit({ description: longDesc }), SITE_URL));
+    expect((course['description'] as string).length).toBeGreaterThan(160);
+  });
+});
+
+// ─── Phase 2: safeHttpsUrl ────────────────────────────────────────────────────
+
+describe('safeHttpsUrl', () => {
+  it('returns the URL for valid https links', () => {
+    expect(safeHttpsUrl('https://handbook.curtin.edu.au/')).toBe('https://handbook.curtin.edu.au/');
+  });
+
+  it('returns undefined for http links', () => {
+    expect(safeHttpsUrl('http://handbook.curtin.edu.au/')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(safeHttpsUrl('')).toBeUndefined();
+  });
+
+  it('returns undefined for undefined', () => {
+    expect(safeHttpsUrl(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for javascript: URLs', () => {
+    expect(safeHttpsUrl('javascript:alert(1)')).toBeUndefined();
+  });
+});
+
+// ─── Phase 3: sitewide graph ──────────────────────────────────────────────────
+
+// ─── Item 2: inLanguage on WebSite ───────────────────────────────────────────
+
+describe('buildSitewideJsonLd — inLanguage', () => {
+  it('sets inLanguage to en-AU on the WebSite node', () => {
+    const website = buildSitewideJsonLd(SITE_URL).find((n) => n['@type'] === 'WebSite')!;
+    expect(website['inLanguage']).toBe('en-AU');
+  });
+});
+
+// ─── Item 5: dateModified on Course ──────────────────────────────────────────
+
+describe('buildUnitJsonLd — dateModified', () => {
+  it('sets dateModified to the latest review createdAt', () => {
+    const unit = baseUnit({
+      numberOfReviews: 2,
+      averageRating: 4,
+      reviews: [
+        {
+          rating: 4,
+          reviewText: 'Good unit.',
+          semesterTaken: 'Sem 1 2024',
+          professor: 'Smith',
+          workload: 5,
+          hasExam: false,
+          wouldTakeAgain: true,
+          reviewerVerified: false,
+          createdAt: '2024-06-01T10:00:00Z',
+        },
+        {
+          rating: 4,
+          reviewText: 'Also good.',
+          semesterTaken: 'Sem 2 2024',
+          professor: 'Jones',
+          workload: 5,
+          hasExam: false,
+          wouldTakeAgain: true,
+          reviewerVerified: false,
+          createdAt: '2025-01-15T08:00:00Z',
+        },
+      ],
+    });
+
+    const course = getCourseNode(buildUnitJsonLd(unit, SITE_URL));
+    expect(course['dateModified']).toBe('2025-01-15T08:00:00Z');
+  });
+
+  it('omits dateModified when no reviews have createdAt', () => {
+    const unit = baseUnit({
+      numberOfReviews: 1,
+      averageRating: 3,
+      reviews: [
+        {
+          rating: 3,
+          reviewText: 'OK.',
+          semesterTaken: 'Sem 1 2025',
+          professor: 'Smith',
+          workload: 5,
+          hasExam: false,
+          wouldTakeAgain: false,
+          reviewerVerified: false,
+        },
+      ],
+    });
+
+    const course = getCourseNode(buildUnitJsonLd(unit, SITE_URL));
+    expect(course['dateModified']).toBeUndefined();
+  });
+
+  it('omits dateModified when there are no reviews', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit(), SITE_URL));
+    expect(course['dateModified']).toBeUndefined();
+  });
+});
+
+describe('buildSitewideJsonLd', () => {
+  it('returns WebSite and Organization nodes', () => {
+    const nodes = buildSitewideJsonLd(SITE_URL);
+    const types = nodes.map((n) => n['@type']);
+    expect(types).toContain('WebSite');
+    expect(types).toContain('Organization');
+  });
+
+  it('WebSite node has correct @id and url', () => {
+    const website = buildSitewideJsonLd(SITE_URL).find((n) => n['@type'] === 'WebSite')!;
+    expect(website['@id']).toBe('https://curtinhonestly.com/#website');
+    expect(website['url']).toBe('https://curtinhonestly.com/');
+  });
+
+  it('Organization node has correct @id and disclaimer description', () => {
+    const org = buildSitewideJsonLd(SITE_URL).find((n) => n['@type'] === 'Organization')!;
+    expect(org['@id']).toBe('https://curtinhonestly.com/#org');
+    expect(org['description']).toBe(
+      'Independent student platform. Not affiliated with Curtin University.'
+    );
+  });
+
+  it('handles trailing slash in siteUrl', () => {
+    const nodes = buildSitewideJsonLd('https://curtinhonestly.com/');
+    const website = nodes.find((n) => n['@type'] === 'WebSite')!;
+    expect(website['@id']).toBe('https://curtinhonestly.com/#website');
+  });
+});
+
+describe('buildUnitJsonLd — Phase 3 sitewide graph', () => {
+  it('includes WebSite and Organization nodes in @graph', () => {
+    const result = buildUnitJsonLd(baseUnit(), SITE_URL);
+    const graph = result['@graph'] as Record<string, unknown>[];
+    const types = graph.map((n) => n['@type']);
+    expect(types).toContain('WebSite');
+    expect(types).toContain('Organization');
+    expect(types).toContain('BreadcrumbList');
+    expect(types).toContain('Course');
+  });
+});
+
+describe('buildHomeJsonLd — Phase 3 sitewide graph', () => {
+  it('returns a @graph with WebSite and Organization', () => {
+    const result = buildHomeJsonLd(SITE_URL);
+    expect(result['@context']).toBe('https://schema.org');
+    const graph = result['@graph'] as Record<string, unknown>[];
+    expect(graph.map((n) => n['@type'])).toContain('WebSite');
+    expect(graph.map((n) => n['@type'])).toContain('Organization');
+  });
+
+  it('does not include CollegeOrUniversity in WebSite.about', () => {
+    const result = buildHomeJsonLd(SITE_URL);
+    const graph = result['@graph'] as Record<string, unknown>[];
+    const website = graph.find((n) => n['@type'] === 'WebSite')!;
+    expect(website['about']).toBeUndefined();
+  });
+});
+
+// ─── Phase 4: hasCourseInstance ───────────────────────────────────────────────
+
+describe('buildUnitJsonLd — Phase 4 hasCourseInstance', () => {
+  it('includes courseWorkload from contactHours as ISO 8601', () => {
+    const course = getCourseNode(buildUnitJsonLd(baseUnit({ contactHours: 3 }), SITE_URL));
+    const instance = course['hasCourseInstance'] as Record<string, unknown>;
+    expect(instance['courseWorkload']).toBe('PT3H');
+  });
+
+  it('omits hasCourseInstance when contactHours is 0 and no tuition patterns', () => {
+    const course = getCourseNode(
+      buildUnitJsonLd(baseUnit({ contactHours: 0, tuitionPatterns: [] }), SITE_URL)
+    );
+    expect(course['hasCourseInstance']).toBeUndefined();
+  });
+
+  it('derives courseMode blended for online lecture + tutorial', () => {
+    const course = getCourseNode(
+      buildUnitJsonLd(
+        baseUnit({
+          contactHours: 0,
+          tuitionPatterns: [
+            { type: 'Lecture', duration: '2 hours' },
+            { type: 'Tutorial', duration: '1 hour' },
+          ],
+        }),
+        SITE_URL
+      )
+    );
+    const instance = course['hasCourseInstance'] as Record<string, unknown>;
+    expect(instance['courseMode']).toBe('blended');
+  });
+
+  it('derives courseMode online for lecture only', () => {
+    const course = getCourseNode(
+      buildUnitJsonLd(
+        baseUnit({
+          contactHours: 0,
+          tuitionPatterns: [{ type: 'Lecture', duration: '2 hours' }],
+        }),
+        SITE_URL
+      )
+    );
+    const instance = course['hasCourseInstance'] as Record<string, unknown>;
+    expect(instance['courseMode']).toBe('online');
+  });
+
+  it('derives courseMode onsite for tutorial only', () => {
+    const course = getCourseNode(
+      buildUnitJsonLd(
+        baseUnit({
+          contactHours: 0,
+          tuitionPatterns: [{ type: 'Tutorial', duration: '2 hours' }],
+        }),
+        SITE_URL
+      )
+    );
+    const instance = course['hasCourseInstance'] as Record<string, unknown>;
+    expect(instance['courseMode']).toBe('onsite');
+  });
+
+  it('omits courseMode for empty tuition patterns', () => {
+    const course = getCourseNode(
+      buildUnitJsonLd(baseUnit({ tuitionPatterns: [], contactHours: 3 }), SITE_URL)
+    );
+    const instance = course['hasCourseInstance'] as Record<string, unknown>;
+    expect(instance['courseMode']).toBeUndefined();
+    expect(instance['courseWorkload']).toBe('PT3H');
+  });
+});

--- a/frontend/src/app/utils/unit-seo.utils.ts
+++ b/frontend/src/app/utils/unit-seo.utils.ts
@@ -1,6 +1,7 @@
-import { UnitDetails } from '../models/unit.model';
+import { Review, TuitionPattern, UnitDetails } from '../models/unit.model';
 
 const MAX_DESCRIPTION_LENGTH = 160;
+const MAX_JSON_LD_REVIEWS = 10;
 
 export function normalizeTakeAgainRatio(ratio: number): number {
   return ratio > 1 ? ratio / 100 : ratio;
@@ -22,8 +23,11 @@ export function homePageDescription(): string {
   return 'Read honest student reviews for Curtin University units. Ratings, workload, grades, and would-take-again scores to help you choose your units.';
 }
 
-export function unitPageTitle(code: string, name: string): string {
-  return `${code} ${name} Reviews | Curtin University | CurtinHonestly`;
+export function unitPageTitle(code: string, name: string, numberOfReviews = 0): string {
+  if (numberOfReviews > 0) {
+    return `${code} ${name} — ${numberOfReviews} Reviews | CurtinHonestly`;
+  }
+  return `${code} ${name} | CurtinHonestly`;
 }
 
 export function unitPageDescription(unit: UnitDetails): string {
@@ -46,67 +50,185 @@ export function unitPagePath(code: string): string {
   return `/units/${encodeURIComponent(code)}`;
 }
 
-export function buildUnitJsonLd(unit: UnitDetails, siteUrl: string) {
-  const url = `${siteUrl.replace(/\/$/, '')}${unitPagePath(unit.code)}`;
-  const graph: Record<string, unknown>[] = [
+export function reviewAuthorName(reviewerVerified: boolean): string {
+  return reviewerVerified ? 'Verified Curtin Student' : 'Student';
+}
+
+export function safeHttpsUrl(url: string | undefined): string | undefined {
+  const trimmed = url?.trim();
+  if (trimmed && /^https:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return undefined;
+}
+
+function reviewsForJsonLd(reviews: Review[]): Review[] {
+  return reviews.filter((review) => review.reviewText?.trim());
+}
+
+function buildReviewJsonLd(review: Review): Record<string, unknown> {
+  const entry: Record<string, unknown> = {
+    '@type': 'Review',
+    author: { '@type': 'Person', name: reviewAuthorName(review.reviewerVerified) },
+    reviewBody: review.reviewText.trim(),
+    reviewRating: {
+      '@type': 'Rating',
+      ratingValue: String(review.rating),
+      bestRating: '5',
+      worstRating: '1',
+    },
+  };
+
+  if (review.createdAt) {
+    entry['datePublished'] = review.createdAt;
+  }
+
+  return entry;
+}
+
+function deriveCourseMode(patterns: TuitionPattern[]): string | undefined {
+  if (!patterns || patterns.length === 0) return undefined;
+
+  const types = patterns.map((p) => p.type.toLowerCase());
+  const hasOnline = types.some(
+    (t) => t.includes('online') || t.includes('lecture')
+  );
+  const hasInPerson = types.some(
+    (t) =>
+      t.includes('tutorial') ||
+      t.includes('workshop') ||
+      t.includes('in-person') ||
+      t.includes('laboratory')
+  );
+
+  if (hasOnline && hasInPerson) return 'blended';
+  if (hasOnline && !hasInPerson) return 'online';
+  if (!hasOnline && hasInPerson) return 'onsite';
+  return undefined;
+}
+
+export function buildSitewideJsonLd(siteUrl: string): Record<string, unknown>[] {
+  const base = siteUrl.replace(/\/$/, '');
+  return [
     {
-      '@type': 'BreadcrumbList',
-      itemListElement: [
-        {
-          '@type': 'ListItem',
-          position: 1,
-          name: 'Curtin University Unit Reviews',
-          item: siteUrl,
-        },
-        {
-          '@type': 'ListItem',
-          position: 2,
-          name: `${unit.code} ${unit.name}`,
-          item: url,
-        },
-      ],
+      '@type': 'WebSite',
+      '@id': `${base}/#website`,
+      url: `${base}/`,
+      name: 'CurtinHonestly',
+      inLanguage: 'en-AU',
+      description: 'Independent student platform for honest Curtin University unit reviews.',
     },
     {
-      '@type': 'Course',
-      name: `${unit.code} — ${unit.name}`,
-      description: truncateDescription(unit.description || unitPageDescription(unit), 300),
-      url,
-      provider: {
-        '@type': 'CollegeOrUniversity',
-        name: 'Curtin University',
-        sameAs: 'https://www.curtin.edu.au/',
-      },
+      '@type': 'Organization',
+      '@id': `${base}/#org`,
+      name: 'CurtinHonestly',
+      url: `${base}/`,
+      logo: `${base}/assets/images/logo.png`,
+      description: 'Independent student platform. Not affiliated with Curtin University.',
     },
   ];
+}
 
-  if (unit.numberOfReviews > 0 && unit.averageRating > 0) {
-    (graph[1] as Record<string, unknown>)['aggregateRating'] = {
+export function buildUnitJsonLd(unit: UnitDetails, siteUrl: string) {
+  const base = siteUrl.replace(/\/$/, '');
+  const url = `${base}${unitPagePath(unit.code)}`;
+  const courseId = `${url}#course`;
+  const breadcrumbId = `${url}#breadcrumb`;
+
+  const course: Record<string, unknown> = {
+    '@type': 'Course',
+    '@id': courseId,
+    name: `${unit.code} — ${unit.name}`,
+    description: (unit.description || unitPageDescription(unit)).replace(/\s+/g, ' ').trim(),
+    courseCode: unit.code,
+    url,
+    provider: {
+      '@type': 'CollegeOrUniversity',
+      name: 'Curtin University',
+      sameAs: 'https://www.curtin.edu.au/',
+    },
+  };
+
+  const handbookUrl = safeHttpsUrl(unit.unitLink);
+  if (handbookUrl) {
+    course['sameAs'] = handbookUrl;
+  }
+
+  if (unit.area?.trim()) {
+    course['about'] = unit.area.trim();
+  }
+
+  if (unit.credits > 0) {
+    course['educationalCredentialAwarded'] = `${unit.credits} credit points`;
+  }
+
+  const courseMode = deriveCourseMode(unit.tuitionPatterns ?? []);
+  const contactHours = unit.contactHours;
+  if (courseMode || (contactHours && contactHours > 0)) {
+    const instance: Record<string, unknown> = { '@type': 'CourseInstance' };
+    if (courseMode) instance['courseMode'] = courseMode;
+    if (contactHours && contactHours > 0) instance['courseWorkload'] = `PT${contactHours}H`;
+    course['hasCourseInstance'] = instance;
+  }
+
+  const eligibleReviews = reviewsForJsonLd(unit.reviews ?? []);
+  const reviewCount = unit.numberOfReviews ?? 0;
+
+  const latestReviewDate = (unit.reviews ?? [])
+    .map((r) => r.createdAt)
+    .filter((d): d is string => Boolean(d))
+    .sort()
+    .at(-1);
+  if (latestReviewDate) {
+    course['dateModified'] = latestReviewDate;
+  }
+
+  if (reviewCount > 0) {
+    course['aggregateRating'] = {
       '@type': 'AggregateRating',
-      ratingValue: unit.averageRating.toFixed(1),
-      reviewCount: unit.numberOfReviews,
+      ratingValue: (unit.averageRating ?? 0).toFixed(1),
+      reviewCount,
       bestRating: '5',
       worstRating: '1',
     };
+
+    if (eligibleReviews.length > 0) {
+      course['review'] = eligibleReviews
+        .slice(0, MAX_JSON_LD_REVIEWS)
+        .map((review) => buildReviewJsonLd(review));
+    }
   }
 
   return {
     '@context': 'https://schema.org',
-    '@graph': graph,
+    '@graph': [
+      ...buildSitewideJsonLd(siteUrl),
+      {
+        '@type': 'BreadcrumbList',
+        '@id': breadcrumbId,
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Home',
+            item: `${base}/`,
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: unit.code,
+            item: url,
+          },
+        ],
+      },
+      course,
+    ],
   };
 }
 
 export function buildHomeJsonLd(siteUrl: string) {
   return {
     '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    name: 'CurtinHonestly',
-    alternateName: 'Curtin Honestly',
-    url: siteUrl,
-    description: homePageDescription(),
-    about: {
-      '@type': 'CollegeOrUniversity',
-      name: 'Curtin University',
-      sameAs: 'https://www.curtin.edu.au/',
-    },
+    '@graph': buildSitewideJsonLd(siteUrl),
   };
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-AU">
 <head>
   <meta charset="utf-8">
   <title>Curtin University Unit Reviews | CurtinHonestly</title>


### PR DESCRIPTION
## Summary
- **Review snippets** — `Course` JSON-LD with gated `aggregateRating` + `review` array; only emitted when `numberOfReviews > 0` to satisfy Google's visible-content parity rule
- **Sitewide graph** — `WebSite` and `Organization` nodes on every indexable page; fixed incorrect `WebSite.about → CollegeOrUniversity` association; added `inLanguage: en-AU`
- **Course enrichment** — `sameAs` (handbook), `about` (subject area), `educationalCredentialAwarded` (credits), `hasCourseInstance` (courseMode + courseWorkload), `dateModified` from latest review, stable `@id` refs on all nodes
- **Title tags** — `ISYS1000 Unit Name — 12 Reviews | CurtinHonestly`; zero-review fallback drops review count
- **Sitemap lastmod** — per-unit dates via new `latestReviewAt` field on `UnitSummaryDTO`; falls back to build date for no-review units
- **Breadcrumbs** — visible `Home → UNIT_CODE` nav matching JSON-LD `BreadcrumbList` labels exactly
- **Auth pages noindexed** — `login`, `register`, `account`, `my-reviews` all call `seoService.noIndex()` on init
- **Security** — `rel="noopener noreferrer"` on all `target="_blank"` links; `og:locale: en_AU`; `html lang="en-AU"`