### PR TITLE
fix(ci): run prod build outside Oryx so unit pages are prerendered

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
+++ b/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
@@ -18,16 +18,41 @@ jobs:
         with:
           submodules: true
           lfs: false
-      - name: Build And Deploy
-        id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend (set-env, fetch unit codes, generate SEO assets, ng build)
+        working-directory: frontend
         env:
           API_URL: ${{ secrets.API_URL }}
           SITE_URL: https://curtinhonestly.com
+        run: npm run build
+
+      - name: Verify unit codes were fetched
+        working-directory: frontend
+        run: |
+          count=$(node -e "console.log(require('./src/generated/unit-codes.json').length)")
+          echo "Prerendering $count unit pages"
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: unit-codes.json is empty — fetch-unit-codes.js failed or API_URL is not set"
+            exit 1
+          fi
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_SAND_081CC7100 }}
           action: upload
           app_location: frontend
           api_location: ''
           output_location: dist/frontend/browser
-          app_build_command: npm run build
+          skip_app_build: true

--- a/frontend/src/app/utils/unit-seo.utils.ts
+++ b/frontend/src/app/utils/unit-seo.utils.ts
@@ -210,13 +210,13 @@ export function buildUnitJsonLd(unit: UnitDetails, siteUrl: string) {
           {
             '@type': 'ListItem',
             position: 1,
-            name: 'Home',
+            name: 'Curtin University Unit Reviews',
             item: `${base}/`,
           },
           {
             '@type': 'ListItem',
             position: 2,
-            name: unit.code,
+            name: `${unit.code} ${unit.name}`,
             item: url,
           },
         ],


### PR DESCRIPTION
The prod SWA workflow passed `API_URL` via the step `env:` block, but Azure SWA's Oryx builder sandboxes `app_build_command` and does not inherit those variables. `fetch-unit-codes.js` saw an empty `API_URL`, defaulted to `localhost`, detected `seoEnabled = false`, and wrote an empty `unit-codes.json`. `ng build` then prerendered zero unit pages — leaving stale Version 1.2 HTML on Azure SWA for all `/units/*` routes despite the SEO PR being fully merged.
## Fix
- Build now runs in explicit GitHub Actions steps where `env:` vars are fully available
- Deploy uses `skip_app_build: true` so Oryx doesn't re-run the build and discard the populated `unit-codes.json`
- Added a hard-fail verification step: exits non-zero if `unit-codes.json` is empty, so this can never silently pass again
## Also included
- Breadcrumb names tightened: position 1 `"Curtin University Unit Reviews"` (was `"Home"`), position 2 `"CODE Name"` (was just `"CODE"`)