### PR TITLE
fix(ci): deploy hotfix for prerender pipeline

### DIFF
--- a/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
+++ b/.github/workflows/azure-static-web-apps-icy-sand-081cc7100.yml
@@ -18,16 +18,41 @@ jobs:
         with:
           submodules: true
           lfs: false
-      - name: Build And Deploy
-        id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend (set-env, fetch unit codes, generate SEO assets, ng build)
+        working-directory: frontend
         env:
           API_URL: ${{ secrets.API_URL }}
           SITE_URL: https://curtinhonestly.com
+        run: npm run build
+
+      - name: Verify unit codes were fetched
+        working-directory: frontend
+        run: |
+          count=$(node -e "console.log(require('./src/generated/unit-codes.json').length)")
+          echo "Prerendering $count unit pages"
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: unit-codes.json is empty — fetch-unit-codes.js failed or API_URL is not set"
+            exit 1
+          fi
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_SAND_081CC7100 }}
           action: upload
           app_location: frontend
           api_location: ''
           output_location: dist/frontend/browser
-          app_build_command: npm run build
+          skip_app_build: true

--- a/frontend/src/app/utils/unit-seo.utils.ts
+++ b/frontend/src/app/utils/unit-seo.utils.ts
@@ -210,13 +210,13 @@ export function buildUnitJsonLd(unit: UnitDetails, siteUrl: string) {
           {
             '@type': 'ListItem',
             position: 1,
-            name: 'Home',
+            name: 'Curtin University Unit Reviews',
             item: `${base}/`,
           },
           {
             '@type': 'ListItem',
             position: 2,
-            name: unit.code,
+            name: `${unit.code} ${unit.name}`,
             item: url,
           },
         ],


### PR DESCRIPTION
Merges hotfix for the prod prerender pipeline bug — unit pages were not being re-prerendered on deploy due to `API_URL` not reaching the Oryx build environment. 