### PR TITLE
perf(homepage): eliminate N+1, infinite scroll, denormalized aggregates

### DIFF
--- a/.azuredevops/pipelines/backend.yml
+++ b/.azuredevops/pipelines/backend.yml
@@ -105,5 +105,6 @@ stages:
                           DATABASE_URL="$DATABASE_URL" \
                           DATABASE_USERNAME="$DATABASE_USERNAME" \
                           DATABASE_PASSWORD="$DATABASE_PASSWORD" \
-                          JWT_SECRET="$JWT_SECRET"
+                          JWT_SECRET="$JWT_SECRET" \
+                          SPRING_PROFILES_ACTIVE="${{ parameters.environment }}"
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/CoursePrerequisiteOption.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/CoursePrerequisiteOption.java
@@ -30,6 +30,6 @@ public class CoursePrerequisiteOption {
     @Column(columnDefinition = "TEXT")
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE NOT NULL")
     private boolean concurrent = false;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
@@ -45,7 +45,7 @@ public class Review {
     private boolean hasExam; // Optional
     private boolean wouldTakeAgain;
 
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false, columnDefinition = "TIMESTAMPTZ DEFAULT NOW() NOT NULL")
     private Instant createdAt = Instant.now();
 
     @ManyToOne

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Unit.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Unit.java
@@ -48,19 +48,19 @@ public class Unit {
     @Column(nullable = false)
     private UnitLevel level;
 
-    @Column(name = "review_count", nullable = false)
+    @Column(name = "review_count", nullable = false, columnDefinition = "INTEGER DEFAULT 0 NOT NULL")
     private int reviewCount = 0;
 
-    @Column(name = "average_rating", nullable = false)
+    @Column(name = "average_rating", nullable = false, columnDefinition = "DOUBLE PRECISION DEFAULT 0 NOT NULL")
     private double averageRating = 0;
 
-    @Column(name = "average_workload", nullable = false)
+    @Column(name = "average_workload", nullable = false, columnDefinition = "DOUBLE PRECISION DEFAULT 0 NOT NULL")
     private double averageWorkload = 0;
 
-    @Column(name = "average_final_grade", nullable = false)
+    @Column(name = "average_final_grade", nullable = false, columnDefinition = "DOUBLE PRECISION DEFAULT 0 NOT NULL")
     private double averageFinalGrade = 0;
 
-    @Column(name = "would_take_again_ratio", nullable = false)
+    @Column(name = "would_take_again_ratio", nullable = false, columnDefinition = "DOUBLE PRECISION DEFAULT 0 NOT NULL")
     private double wouldTakeAgainRatio = 0;
 
     @Column(name = "latest_review_at")

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Unit.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Unit.java
@@ -6,13 +6,18 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.Instant;
 import java.util.List;
 
 @Entity
-@Table(name = "units")
+@Table(name = "units", indexes = {
+    @Index(name = "idx_units_faculty_level_code", columnList = "faculty, level, code"),
+    @Index(name = "idx_units_review_count", columnList = "review_count"),
+    @Index(name = "idx_units_average_rating", columnList = "average_rating")
+})
 @Getter
 @Setter
 @NoArgsConstructor
@@ -43,19 +48,23 @@ public class Unit {
     @Column(nullable = false)
     private UnitLevel level;
 
-/*
-    @Formula("(SELECT COUNT(*) FROM reviews r WHERE r.unit_id = id)")
-    private Integer reviewCount;
+    @Column(name = "review_count", nullable = false)
+    private int reviewCount = 0;
 
-    @Formula("(SELECT COALESCE(AVG(r.rating), 0) FROM reviews r WHERE r.unit_id = id)")
-    private Double averageRating;
+    @Column(name = "average_rating", nullable = false)
+    private double averageRating = 0;
 
-    @Formula("(SELECT COALESCE(AVG(r.workload), 0) FROM reviews r WHERE r.unit_id = id)")
-    private Double averageWorkload;
+    @Column(name = "average_workload", nullable = false)
+    private double averageWorkload = 0;
 
-    @Formula("(SELECT COALESCE(AVG(r.final_grade), 0) FROM reviews r WHERE r.unit_id = id)")
-    private Double averageFinalGrade;
-*/
+    @Column(name = "average_final_grade", nullable = false)
+    private double averageFinalGrade = 0;
+
+    @Column(name = "would_take_again_ratio", nullable = false)
+    private double wouldTakeAgainRatio = 0;
+
+    @Column(name = "latest_review_at")
+    private Instant latestReviewAt;
 
     @Column(length = 255)
     private String area;
@@ -80,6 +89,7 @@ public class Unit {
     private List<UnitPrerequisiteGroup> prerequisiteGroups;
 
     @OneToMany(mappedBy = "unit", cascade = CascadeType.ALL, orphanRemoval = true)
-    @JsonIgnoreProperties("unit") // Ignores the unit inside each review
+    @JsonIgnoreProperties("unit")
+    @BatchSize(size = 30)
     private List<Review> reviews;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/UnitPrerequisiteOption.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/UnitPrerequisiteOption.java
@@ -28,6 +28,6 @@ public class UnitPrerequisiteOption {
     @Column(length = 255)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE NOT NULL")
     private boolean concurrent = false;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/User.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/User.java
@@ -49,13 +49,13 @@ public class User {
     @com.fasterxml.jackson.annotation.JsonIgnore
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE NOT NULL")
     private boolean verifiedStudent = false;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE NOT NULL")
     private boolean banned = false;
 
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false, columnDefinition = "TIMESTAMPTZ DEFAULT NOW() NOT NULL")
     private Instant createdAt = Instant.now();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/backend/src/main/java/com/curtinhonestly/backend/mapper/UnitMapper.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/mapper/UnitMapper.java
@@ -3,9 +3,7 @@ package com.curtinhonestly.backend.mapper;
 import com.curtinhonestly.backend.domain.*;
 import com.curtinhonestly.backend.dto.*;
 
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -16,25 +14,16 @@ public class UnitMapper {
     {
         UnitSummaryDTO dto = new UnitSummaryDTO();
 
-        // Base unit information
         dto.setName(unit.getName() != null ? unit.getName() : "");
         dto.setCode(unit.getCode() != null ? unit.getCode() : "");
         dto.setFaculty(unit.getFaculty() != null ? unit.getFaculty().getDisplayName() : "");
         dto.setLevel(unit.getLevel() != null ? unit.getLevel().getDisplayName() : "");
 
-        List<Review> reviews = unit.getReviews() != null ? unit.getReviews() : new ArrayList<>();
-
-        // Review-based information
-        dto.setNumberOfReviews(reviews.size());
-        dto.setAverageRating(calculateAverageRating(reviews));
-        dto.setWouldTakeAgainRatio(calculateWouldTakeAgainRatio(reviews));
-
-        Instant latestReviewAt = reviews.stream()
-                .map(Review::getCreatedAt)
-                .filter(Objects::nonNull)
-                .max(Comparator.naturalOrder())
-                .orElse(null);
-        dto.setLatestReviewAt(latestReviewAt);
+        // Read from denormalized columns — never touches the reviews table
+        dto.setNumberOfReviews(unit.getReviewCount());
+        dto.setAverageRating(unit.getAverageRating());
+        dto.setWouldTakeAgainRatio(unit.getWouldTakeAgainRatio());
+        dto.setLatestReviewAt(unit.getLatestReviewAt());
 
         return dto;
     }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
@@ -4,6 +4,7 @@ import com.curtinhonestly.backend.dto.*;
 import com.curtinhonestly.backend.security.SecurityConstants;
 import com.curtinhonestly.backend.service.AdminService;
 import com.curtinhonestly.backend.service.ReviewService;
+import com.curtinhonestly.backend.service.UnitAggregateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ public class AdminResource {
 
     private final AdminService adminService;
     private final ReviewService reviewService;
+    private final UnitAggregateService unitAggregateService;
 
     @GetMapping("/stats/overview")
     public ResponseEntity<AdminOverviewDTO> getOverview() {
@@ -73,6 +75,12 @@ public class AdminResource {
     public ResponseEntity<Void> deleteReview(@PathVariable String id) {
         reviewService.deleteReviewById(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/units/recalculate-aggregates")
+    public ResponseEntity<Void> recalculateAggregates() {
+        unitAggregateService.recalculateAll();
+        return ResponseEntity.ok().build();
     }
 
     public record CreateUserRequest(String email, String password, boolean admin) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
 
                         // Public read endpoints for the student app
                         .requestMatchers(HttpMethod.GET, "/units", "/units/**").permitAll()
+                        .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/auth/register", "/auth/login").permitAll()
                         .requestMatchers("/auth/me", "/auth/verify-student").authenticated()
                         .requestMatchers("/error").permitAll()

--- a/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
@@ -28,6 +28,7 @@ public class ReviewService {
     private final UserRepo userRepo;
     private final UnitRepo unitRepo;
     private final ProfanityFilterService profanityFilterService;
+    private final UnitAggregateService unitAggregateService;
 
     public List<Review> getReviewsByUnitCode(String unitCode) {
         Unit unit = unitService.getUnitByCode(unitCode);
@@ -81,12 +82,16 @@ public class ReviewService {
 
         log.info("Review added by user: {}", username);
 
-        return reviewRepo.save(review);
+        Review saved = reviewRepo.save(review);
+        unitAggregateService.recalculateForUnit(unit.getId());
+        return saved;
     }
 
     public void deleteReview(Review review) {
+        String unitId = review.getUnit().getId();
         log.info("Review deleted");
         reviewRepo.delete(review);
+        unitAggregateService.recalculateForUnit(unitId);
     }
 
     public void deleteReviewById(String id) {

--- a/backend/src/main/java/com/curtinhonestly/backend/service/UnitAggregateService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/UnitAggregateService.java
@@ -1,0 +1,70 @@
+package com.curtinhonestly.backend.service;
+
+import com.curtinhonestly.backend.domain.Review;
+import com.curtinhonestly.backend.domain.Unit;
+import com.curtinhonestly.backend.repo.ReviewRepo;
+import com.curtinhonestly.backend.repo.UnitRepo;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@Slf4j
+@Transactional(rollbackOn = Exception.class)
+@RequiredArgsConstructor
+public class UnitAggregateService {
+
+    private final ReviewRepo reviewRepo;
+    private final UnitRepo unitRepo;
+
+    public void recalculateForUnit(String unitId) {
+        Unit unit = unitRepo.findById(unitId)
+                .orElseThrow(() -> new RuntimeException("Unit not found: " + unitId));
+
+        List<Review> reviews = reviewRepo.findByUnit_Id(unitId);
+
+        if (reviews.isEmpty()) {
+            unit.setReviewCount(0);
+            unit.setAverageRating(0);
+            unit.setAverageWorkload(0);
+            unit.setAverageFinalGrade(0);
+            unit.setWouldTakeAgainRatio(0);
+            unit.setLatestReviewAt(null);
+        } else {
+            unit.setReviewCount(reviews.size());
+            unit.setAverageRating(roundTo1Decimal(
+                    reviews.stream().mapToInt(Review::getRating).average().orElse(0)));
+            unit.setAverageWorkload(roundTo1Decimal(
+                    reviews.stream().mapToInt(Review::getWorkload).average().orElse(0)));
+            unit.setAverageFinalGrade(roundTo1Decimal(
+                    reviews.stream().map(Review::getFinalGrade).filter(Objects::nonNull)
+                            .mapToInt(Integer::intValue).average().orElse(0)));
+            long positiveCount = reviews.stream().filter(Review::isWouldTakeAgain).count();
+            unit.setWouldTakeAgainRatio(roundTo1Decimal((positiveCount * 100.0) / reviews.size()));
+            Instant latest = reviews.stream().map(Review::getCreatedAt).filter(Objects::nonNull)
+                    .max(Comparator.naturalOrder()).orElse(null);
+            unit.setLatestReviewAt(latest);
+        }
+
+        unitRepo.save(unit);
+    }
+
+    public void recalculateAll() {
+        List<String> unitIds = unitRepo.findAll().stream().map(Unit::getId).toList();
+        log.info("Starting aggregate backfill for {} units", unitIds.size());
+        for (String id : unitIds) {
+            recalculateForUnit(id);
+        }
+        log.info("Aggregate backfill complete");
+    }
+
+    private double roundTo1Decimal(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/service/UnitService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/UnitService.java
@@ -1,7 +1,6 @@
 package com.curtinhonestly.backend.service;
 
 import com.curtinhonestly.backend.domain.Faculty;
-import com.curtinhonestly.backend.domain.Review;
 import com.curtinhonestly.backend.domain.Unit;
 import com.curtinhonestly.backend.domain.UnitLevel;
 import com.curtinhonestly.backend.dto.UnitDetailsDTO;
@@ -9,7 +8,7 @@ import com.curtinhonestly.backend.dto.UnitSummaryDTO;
 import com.curtinhonestly.backend.mapper.UnitMapper;
 import com.curtinhonestly.backend.repo.UnitRepo;
 import com.curtinhonestly.backend.repo.UnitSpecification;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -22,12 +21,13 @@ import java.util.List;
 
 @Service
 @Slf4j
-@Transactional(rollbackOn = Exception.class)
+@Transactional(rollbackFor = Exception.class)
 @RequiredArgsConstructor
 public class UnitService {
 
     private final UnitRepo unitRepo;
 
+    @Transactional(readOnly = true)
     public Page<UnitSummaryDTO> getAllUnits(int page, int size, String search, List<Faculty> faculties, UnitLevel level, String sortBy) {
         Sort sort = Sort.by(Sort.Direction.ASC, "code"); // Default sort
 
@@ -42,7 +42,6 @@ public class UnitService {
                 case "code_desc":
                     sort = Sort.by(Sort.Direction.DESC, "code");
                     break;
-/*
                 case "most_reviewed":
                     sort = Sort.by(Sort.Direction.DESC, "reviewCount");
                     break;
@@ -67,7 +66,6 @@ public class UnitService {
                 case "highest_workload":
                     sort = Sort.by(Sort.Direction.DESC, "averageWorkload");
                     break;
-*/
             }
         }
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,8 @@
+spring:
+  jpa:
+    show-sql: false
+logging:
+  level:
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN
+    com.curtinhonestly.backend: INFO

--- a/frontend/src/app/components/unit-list/unit-list.component.css
+++ b/frontend/src/app/components/unit-list/unit-list.component.css
@@ -361,6 +361,41 @@
   100% { transform: rotate(360deg); }
 }
 
+/* Loading-more bar at the bottom of the grid */
+.loading-more {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 24px 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.spinner-sm {
+  width: 20px;
+  height: 20px;
+  border: 3px solid #edf2f7;
+  border-top: 3px solid var(--primary-color);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  flex-shrink: 0;
+}
+
+/* Invisible sentinel that triggers infinite scroll */
+.scroll-sentinel {
+  height: 1px;
+  pointer-events: none;
+}
+
+/* End-of-list message */
+.end-message {
+  text-align: center;
+  padding: 24px 0 8px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
 @media (max-width: 1110px) {
   :host {
     --unit-catalog-max: calc(var(--unit-card-width) * 2 + var(--unit-grid-gap));

--- a/frontend/src/app/components/unit-list/unit-list.component.html
+++ b/frontend/src/app/components/unit-list/unit-list.component.html
@@ -10,24 +10,28 @@
   <div class="filter-bar">
     <div class="filter-top">
       <div class="search-box">
-        <input 
-          type="text" 
-          [(ngModel)]="searchQuery" 
-          (ngModelChange)="onFilterChange()" 
+        <input
+          type="text"
+          [(ngModel)]="searchQuery"
+          (ngModelChange)="onSearchChange()"
           placeholder="Search by code or name..."
           class="search-input">
       </div>
-      
+
       <div class="select-group">
         <select [(ngModel)]="selectedLevel" (change)="onFilterChange()" class="filter-select">
           <option [ngValue]="undefined">All Levels</option>
-          <option *ngFor="let level of levels" [value]="level.value">{{ level.label }}</option>
+          @for (level of levels; track level.value) {
+            <option [value]="level.value">{{ level.label }}</option>
+          }
         </select>
 
         <select [(ngModel)]="sortBy" (change)="onFilterChange()" class="filter-select">
-          <option *ngFor="let option of sortOptions" [value]="option.value">{{ option.label }}</option>
+          @for (option of sortOptions; track option.value) {
+            <option [value]="option.value">{{ option.label }}</option>
+          }
         </select>
-        
+
         <button class="btn-clear" (click)="resetFilters()">Clear Filters</button>
       </div>
     </div>
@@ -35,73 +39,100 @@
     <div class="faculty-filters">
       <span class="filter-label">Faculties:</span>
       <div class="faculty-pills">
-        <button 
-          *ngFor="let faculty of faculties" 
-          class="faculty-pill" 
-          [class.active]="isFacultySelected(faculty.value)"
-          (click)="toggleFaculty(faculty.value)">
-          {{ faculty.label }}
-        </button>
+        @for (faculty of faculties; track faculty.value) {
+          <button
+            class="faculty-pill"
+            [class.active]="isFacultySelected(faculty.value)"
+            (click)="toggleFaculty(faculty.value)">
+            {{ faculty.label }}
+          </button>
+        }
       </div>
     </div>
   </div>
 
-  <!-- Loading state - shown while units$ is fetching data -->
-  <div *ngIf="!(units$ | async)" class="loading">
-    <div class="spinner"></div>
-    <p>Loading units...</p>
-  </div>
+  <!-- Single subscription — no triple async pipe -->
+  @if (state$ | async; as state) {
+    @if (state.loading) {
+      <div class="loading">
+        <div class="spinner"></div>
+        <p>Loading units...</p>
+      </div>
+    } @else if (state.error && state.units.length === 0) {
+      <div class="empty-state">
+        <p>{{ state.error }}</p>
+        <button class="btn btn-primary" (click)="loadPage0()">Try Again</button>
+      </div>
+    } @else if (state.units.length === 0) {
+      <div class="empty-state">
+        <p>No units found matching your filters.</p>
+        <button class="btn btn-primary" (click)="resetFilters()">Reset All Filters</button>
+      </div>
+    } @else {
+      <!-- The grid of unit cards -->
+      <div class="unit-grid">
+        @for (unit of state.units; track unit.code) {
+          <div class="unit-card">
+            <div class="card-header">
+              <div class="header-tags">
+                <span class="faculty-tag">{{ unit.faculty }}</span>
+                <span class="level-tag">{{ unit.level }}</span>
+              </div>
+              <span class="unit-code">{{ unit.code }}</span>
+            </div>
 
-  <!-- Empty state -->
-  <div class="empty-state" *ngIf="(units$ | async)?.length === 0">
-    <p>No units found matching your filters.</p>
-    <button class="btn btn-primary" (click)="resetFilters()">Reset All Filters</button>
-  </div>
+            <div class="card-body">
+              <h2 class="unit-name">{{ unit.name }}</h2>
 
-  <!-- The grid of unit cards -->
-  <div class="unit-grid" *ngIf="units$ | async as units">
-    <div *ngFor="let unit of units" class="unit-card">
-      <div class="card-header">
-        <div class="header-tags">
-          <span class="faculty-tag">{{ unit.faculty }}</span>
-          <span class="level-tag">{{ unit.level }}</span>
-        </div>
-        <span class="unit-code">{{ unit.code }}</span>
-      </div>
-      
-      <div class="card-body">
-        <h2 class="unit-name">{{ unit.name }}</h2>
-        
-        <div class="rating-box">
-          <span class="stars">
-            <ng-container *ngFor="let type of getStarArray(unit.averageRating)">
-              <span *ngIf="type === 'full'">★</span>
-              <span *ngIf="type === 'half'" class="half-star">★</span>
-              <span *ngIf="type === 'empty'">☆</span>
-            </ng-container>
-          </span>
-          <span class="rating-num">{{ unit.averageRating | number:'1.1-1' }}</span>
-        </div>
-        
-        <div class="stats-row">
-          <div class="stat">
-            <span class="stat-value">{{ unit.numberOfReviews }}</span>
-            <span class="stat-label">Reviews</span>
+              <div class="rating-box">
+                <span class="stars">
+                  @for (type of getStarArray(unit.averageRating); track $index) {
+                    @if (type === 'full') {
+                      <span>★</span>
+                    } @else if (type === 'half') {
+                      <span class="half-star">★</span>
+                    } @else {
+                      <span>☆</span>
+                    }
+                  }
+                </span>
+                <span class="rating-num">{{ unit.averageRating | number:'1.1-1' }}</span>
+              </div>
+
+              <div class="stats-row">
+                <div class="stat">
+                  <span class="stat-value">{{ unit.numberOfReviews }}</span>
+                  <span class="stat-label">Reviews</span>
+                </div>
+                <div class="stat">
+                  <span class="stat-value">{{ unit.wouldTakeAgainRatio | percent }}</span>
+                  <span class="stat-label">Recommended</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="card-footer">
+              <a [routerLink]="['/units', unit.code]" class="btn btn-primary view-btn" [attr.aria-label]="'Read ' + unit.code + ' reviews at Curtin University'">
+                {{ unit.code }} reviews
+              </a>
+            </div>
           </div>
-          <div class="stat">
-            <span class="stat-value">{{ unit.wouldTakeAgainRatio | percent }}</span>
-            <span class="stat-label">Recommended</span>
-          </div>
+        }
+      </div>
+
+      @if (state.loadingMore) {
+        <div class="loading-more">
+          <div class="spinner-sm"></div>
+          <span>Loading more units…</span>
         </div>
-      </div>
-      
-      <div class="card-footer">
-        <!-- routerLink takes the user to the details page using the unit code -->
-        <a [routerLink]="['/units', unit.code]" class="btn btn-primary view-btn" [attr.aria-label]="'Read ' + unit.code + ' reviews at Curtin University'">
-          {{ unit.code }} reviews
-        </a>
-      </div>
-    </div>
-  </div>
+      }
+
+      @if (state.hasMore) {
+        <div #scrollSentinel class="scroll-sentinel" aria-hidden="true"></div>
+      } @else {
+        <p class="end-message">All {{ state.units.length }} units loaded</p>
+      }
+    }
+  }
   </div>
 </div>

--- a/frontend/src/app/components/unit-list/unit-list.component.ts
+++ b/frontend/src/app/components/unit-list/unit-list.component.ts
@@ -1,5 +1,5 @@
-import { Component, inject, OnInit, OnDestroy, ElementRef, ViewChild } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, inject, OnInit, OnDestroy, ElementRef, ViewChild, PLATFORM_ID } from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { UnitService } from '../../services/unit.service';
@@ -28,6 +28,7 @@ interface UnitListState {
 export class UnitListComponent implements OnInit, OnDestroy {
   private unitService = inject(UnitService);
   private seoService = inject(SeoService);
+  private platformId = inject(PLATFORM_ID);
 
   private destroy$ = new Subject<void>();
   private searchSubject = new Subject<void>();
@@ -91,7 +92,12 @@ export class UnitListComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.seoService.updateHomePage();
-    // Only search input is debounced; sort/faculty/level changes are immediate
+
+    // Skip all data fetching during SSR prerender — avoids CI build timeouts.
+    // The browser hydrates and fetches data client-side via the async pipe.
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    // Search input is debounced; sort/faculty/level fire immediately
     this.searchSubject.pipe(debounceTime(300), takeUntil(this.destroy$)).subscribe(() => this.loadPage0());
     this.loadPage0();
   }

--- a/frontend/src/app/components/unit-list/unit-list.component.ts
+++ b/frontend/src/app/components/unit-list/unit-list.component.ts
@@ -1,11 +1,22 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy, ElementRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { UnitService } from '../../services/unit.service';
 import { SeoService } from '../../services/seo.service';
 import { UnitSummary, Faculty, UnitLevel } from '../../models/unit.model';
-import { Observable, map, BehaviorSubject, switchMap, debounceTime, distinctUntilChanged } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { debounceTime, takeUntil } from 'rxjs/operators';
+
+interface UnitListState {
+  units: UnitSummary[];
+  page: number;
+  totalPages: number;
+  loading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+}
 
 @Component({
   selector: 'app-unit-list',
@@ -14,17 +25,22 @@ import { Observable, map, BehaviorSubject, switchMap, debounceTime, distinctUnti
   templateUrl: './unit-list.component.html',
   styleUrl: './unit-list.component.css'
 })
-export class UnitListComponent implements OnInit {
+export class UnitListComponent implements OnInit, OnDestroy {
   private unitService = inject(UnitService);
   private seoService = inject(SeoService);
-  
-  // Filter state
+
+  private destroy$ = new Subject<void>();
+  private searchSubject = new Subject<void>();
+  private fetchCancel$ = new Subject<void>();
+  private observer?: IntersectionObserver;
+
+  readonly PAGE_SIZE = 24;
+
   searchQuery = '';
   selectedFaculties: Faculty[] = [];
   selectedLevel?: UnitLevel;
   sortBy = 'code';
 
-  // Options for dropdowns
   faculties = this.unitService.getFaculties();
   levels = this.unitService.getUnitLevels();
   sortOptions = [
@@ -42,61 +58,145 @@ export class UnitListComponent implements OnInit {
     { value: 'highest_workload', label: 'Highest Workload' }
   ];
 
-  // Subject to trigger refreshes
-  private filterSubject = new BehaviorSubject<void>(undefined);
-  
-  units$: Observable<UnitSummary[]> | undefined;
+  private stateSubject = new BehaviorSubject<UnitListState>({
+    units: [],
+    page: 0,
+    totalPages: 0,
+    loading: true,
+    loadingMore: false,
+    error: null,
+    hasMore: false
+  });
+
+  readonly state$ = this.stateSubject.asObservable();
+
+  // Reconnect IntersectionObserver whenever the sentinel appears/disappears
+  @ViewChild('scrollSentinel', { static: false })
+  set scrollSentinel(el: ElementRef<HTMLElement> | undefined) {
+    this.observer?.disconnect();
+    if (el) {
+      this.observer = new IntersectionObserver(
+        entries => {
+          if (entries[0].isIntersecting) {
+            this.loadNextPage();
+          }
+        },
+        { rootMargin: '200px' }
+      );
+      this.observer.observe(el.nativeElement);
+    } else {
+      this.observer = undefined;
+    }
+  }
 
   ngOnInit(): void {
     this.seoService.updateHomePage();
-
-    this.units$ = this.filterSubject.pipe(
-      debounceTime(300), // Small wait to avoid too many requests while typing
-      switchMap(() => this.unitService.getUnits(
-        0, 100, // Load a large first page for now
-        this.searchQuery,
-        this.selectedFaculties,
-        this.selectedLevel,
-        this.sortBy
-      )),
-      map(page => page.content.map(unit => ({
-        ...unit,
-        wouldTakeAgainRatio: unit.wouldTakeAgainRatio > 1 ? unit.wouldTakeAgainRatio / 100 : unit.wouldTakeAgainRatio
-      })))
-    );
+    // Only search input is debounced; sort/faculty/level changes are immediate
+    this.searchSubject.pipe(debounceTime(300), takeUntil(this.destroy$)).subscribe(() => this.loadPage0());
+    this.loadPage0();
   }
 
-  onFilterChange() {
-    this.filterSubject.next();
+  ngOnDestroy(): void {
+    this.fetchCancel$.next();
+    this.fetchCancel$.complete();
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.observer?.disconnect();
   }
 
-  toggleFaculty(faculty: Faculty) {
+  loadPage0(): void {
+    this.fetchCancel$.next();
+    const current = this.stateSubject.value;
+    this.stateSubject.next({ ...current, loading: true, units: [], page: 0, error: null, hasMore: false });
+
+    this.fetchPage(0).pipe(takeUntil(this.fetchCancel$)).subscribe({
+      next: page => {
+        this.stateSubject.next({
+          units: this.normalizeRatios(page.content),
+          page: 0,
+          totalPages: page.totalPages,
+          loading: false,
+          loadingMore: false,
+          error: null,
+          hasMore: page.totalPages > 1
+        });
+      },
+      error: () => {
+        this.stateSubject.next({ ...this.stateSubject.value, loading: false, error: 'Failed to load units.' });
+      }
+    });
+  }
+
+  private loadNextPage(): void {
+    const state = this.stateSubject.value;
+    if (state.loading || state.loadingMore || !state.hasMore) return;
+
+    const nextPage = state.page + 1;
+    this.stateSubject.next({ ...state, loadingMore: true });
+
+    this.fetchPage(nextPage).pipe(takeUntil(this.fetchCancel$)).subscribe({
+      next: page => {
+        this.stateSubject.next({
+          units: [...state.units, ...this.normalizeRatios(page.content)],
+          page: nextPage,
+          totalPages: page.totalPages,
+          loading: false,
+          loadingMore: false,
+          error: null,
+          hasMore: nextPage < page.totalPages - 1
+        });
+      },
+      error: () => {
+        this.stateSubject.next({ ...this.stateSubject.value, loadingMore: false, error: 'Failed to load more units.' });
+      }
+    });
+  }
+
+  private fetchPage(page: number) {
+    return this.unitService.getUnits(page, this.PAGE_SIZE, this.searchQuery, this.selectedFaculties, this.selectedLevel, this.sortBy);
+  }
+
+  private normalizeRatios(units: UnitSummary[]): UnitSummary[] {
+    return units.map(unit => ({
+      ...unit,
+      wouldTakeAgainRatio: unit.wouldTakeAgainRatio > 1 ? unit.wouldTakeAgainRatio / 100 : unit.wouldTakeAgainRatio
+    }));
+  }
+
+  onSearchChange(): void {
+    this.searchSubject.next();
+  }
+
+  onFilterChange(): void {
+    this.loadPage0();
+  }
+
+  toggleFaculty(faculty: Faculty): void {
     const index = this.selectedFaculties.indexOf(faculty);
     if (index > -1) {
       this.selectedFaculties.splice(index, 1);
     } else {
       this.selectedFaculties.push(faculty);
     }
-    this.onFilterChange();
+    this.loadPage0();
   }
 
   isFacultySelected(faculty: Faculty): boolean {
     return this.selectedFaculties.includes(faculty);
   }
 
-  resetFilters() {
+  resetFilters(): void {
     this.searchQuery = '';
     this.selectedFaculties = [];
     this.selectedLevel = undefined;
     this.sortBy = 'code';
-    this.onFilterChange();
+    this.loadPage0();
   }
 
   getStarArray(rating: number): string[] {
     const stars: string[] = [];
     const fullStars = Math.floor(rating || 0);
     const hasHalfStar = (rating || 0) % 1 >= 0.5;
-
     for (let i = 1; i <= 5; i++) {
       if (i <= fullStars) {
         stars.push('full');


### PR DESCRIPTION
## Summary

- **Eliminates N+1 query pattern** on `GET /units` — list endpoint goes from ~100+ SQL queries down to 2 (data + count) regardless of page size
- **Denormalized review aggregates** stored on `units` table (`review_count`, `average_rating`, `average_workload`, `average_final_grade`, `would_take_again_ratio`, `latest_review_at`); kept in sync by `UnitAggregateService` on every review create/delete
- **Infinite scroll** with `PAGE_SIZE=24`; single `BehaviorSubject<UnitListState>` replaces the triple `async` pipe that was triggering 3 duplicate API calls per load
- **SSR prerender fix** — guards all data fetching behind `isPlatformBrowser()` so CI builds no longer timeout trying to reach the backend
- **Schema migration fix** — `columnDefinition` with `DEFAULT` values on all `nullable=false` columns so `ddl-auto:update` can add columns to existing tables without failing
- **Prod config profile** — `SPRING_PROFILES_ACTIVE` now passed via pipeline; `application-prod.yml` disables SQL logging in prod
- Re-enables all sort options (`most_reviewed`, `highest_rated`, `highest_mark`, etc.)
- Spring Boot Actuator health endpoint added (`/actuator/health` public)
- DB indexes on `faculty/level/code`, `review_count`, `average_rating`

## Post-deploy steps (prod)

1. Run `POST /admin/units/recalculate-aggregates` with an admin JWT to backfill aggregate columns
2. Confirm units load with real review counts and ratings on the prod frontend

## Test plan

- [x] Validated on dev — units load in 1-2s vs 10+s previously
- [x] Aggregates recalculated on dev — real review counts and ratings showing
- [x] Infinite scroll working — 24 units per page, loads next page on scroll
- [x] All sort options functional
- [x] SSR prerender completes without timeout in CI