### PR TITLE
feat: Campaign promo codes, referral links, and draw entry tokens (v2)

### DIFF
--- a/admin-frontend/src/app/app.html
+++ b/admin-frontend/src/app/app.html
@@ -10,6 +10,7 @@
         <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Overview</a>
         <a routerLink="/analytics" routerLinkActive="active">Analytics</a>
         <a routerLink="/operations" routerLinkActive="active">Operations</a>
+        <a routerLink="/campaigns" routerLinkActive="active">Campaigns</a>
       </nav>
 
       <div class="user-actions">

--- a/admin-frontend/src/app/app.routes.ts
+++ b/admin-frontend/src/app/app.routes.ts
@@ -4,11 +4,13 @@ import { LoginComponent } from './pages/login/login.component';
 import { OverviewComponent } from './pages/overview/overview.component';
 import { AnalyticsComponent } from './pages/analytics/analytics.component';
 import { OperationsComponent } from './pages/operations/operations.component';
+import { CampaignsComponent } from './pages/campaigns/campaigns.component';
 
 export const routes: Routes = [
   { path: 'login', component: LoginComponent },
   { path: '', component: OverviewComponent, canActivate: [adminGuard] },
   { path: 'analytics', component: AnalyticsComponent, canActivate: [adminGuard] },
   { path: 'operations', component: OperationsComponent, canActivate: [adminGuard] },
+  { path: 'campaigns', component: CampaignsComponent, canActivate: [adminGuard] },
   { path: '**', redirectTo: '' }
 ];

--- a/admin-frontend/src/app/models/admin.model.ts
+++ b/admin-frontend/src/app/models/admin.model.ts
@@ -58,6 +58,8 @@ export interface CampaignAdmin {
   maxRedemptions: number | null;
   minReviewLength: number;
   maxEntriesPerUser: number;
+  requireVerifiedStudent: boolean;
+  requiredReviewCount: number;
   signupCount: number;
   entryCount: number;
   createdAt: string;

--- a/admin-frontend/src/app/models/admin.model.ts
+++ b/admin-frontend/src/app/models/admin.model.ts
@@ -45,3 +45,28 @@ export interface PagedReviews {
   totalPages: number;
   number: number;
 }
+
+export interface CampaignAdmin {
+  id: string;
+  slug: string;
+  code: string;
+  name: string;
+  prizeDescription: string | null;
+  startsAt: string;
+  endsAt: string;
+  active: boolean;
+  maxRedemptions: number | null;
+  minReviewLength: number;
+  maxEntriesPerUser: number;
+  signupCount: number;
+  entryCount: number;
+  createdAt: string;
+}
+
+export interface CampaignEntryAdmin {
+  id: string;
+  entryToken: string;
+  userEmail: string;
+  unitCode: string;
+  createdAt: string;
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.css
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.css
@@ -64,3 +64,10 @@ code {
   font-family: monospace;
   font-size: 0.85rem;
 }
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.css
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.css
@@ -1,0 +1,66 @@
+.section {
+  margin-bottom: 16px;
+}
+
+h2 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.form-grid input {
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.subtle {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.section-header h2 {
+  margin: 0;
+}
+
+.success-banner {
+  background: #ecfdf3;
+  border: 1px solid #abefc6;
+  color: var(--success-color);
+  padding: 10px 12px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+code {
+  font-family: monospace;
+  font-size: 0.85rem;
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.html
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.html
@@ -1,0 +1,113 @@
+<h1 class="page-title">Campaigns</h1>
+<p class="page-subtitle">Create outreach campaigns with referral links, promo codes, and draw entry tracking.</p>
+
+@if (errorMessage()) {
+  <div class="error-banner">{{ errorMessage() }}</div>
+}
+@if (successMessage()) {
+  <div class="success-banner">{{ successMessage() }}</div>
+}
+
+<section class="card section">
+  <h2>Create campaign</h2>
+  <div class="form-grid">
+    <input type="text" placeholder="Slug (ref param), e.g. discord-computing-jul26" [(ngModel)]="slug" name="slug" />
+    <input type="text" placeholder="Promo code, e.g. CURTIN-JUL26" [(ngModel)]="code" name="code" />
+    <input type="text" placeholder="Campaign name" [(ngModel)]="name" name="name" />
+    <input type="text" placeholder="Prize description" [(ngModel)]="prizeDescription" name="prizeDescription" />
+    <label>
+      Starts
+      <input type="datetime-local" [(ngModel)]="startsAt" name="startsAt" />
+    </label>
+    <label>
+      Ends
+      <input type="datetime-local" [(ngModel)]="endsAt" name="endsAt" />
+    </label>
+    <input type="number" placeholder="Max signups (optional)" [(ngModel)]="maxRedemptions" name="maxRedemptions" />
+    <input type="number" placeholder="Min review length" [(ngModel)]="minReviewLength" name="minReviewLength" />
+    <input type="number" placeholder="Max entries per user" [(ngModel)]="maxEntriesPerUser" name="maxEntriesPerUser" />
+  </div>
+  <button type="button" class="btn btn-primary" (click)="createCampaign()">Create campaign</button>
+</section>
+
+<section class="card section">
+  <h2>Campaigns</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Slug / Code</th>
+        <th>Window</th>
+        <th>Signups</th>
+        <th>Entries</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (campaign of campaigns(); track campaign.id) {
+        <tr>
+          <td>
+            <strong>{{ campaign.name }}</strong>
+            @if (campaign.prizeDescription) {
+              <div class="subtle">{{ campaign.prizeDescription }}</div>
+            }
+          </td>
+          <td>
+            <div><code>{{ campaign.slug }}</code></div>
+            <div><code>{{ campaign.code }}</code></div>
+          </td>
+          <td>
+            {{ campaign.startsAt | date: 'mediumDate' }} –
+            {{ campaign.endsAt | date: 'mediumDate' }}
+          </td>
+          <td>{{ campaign.signupCount }}</td>
+          <td>{{ campaign.entryCount }}</td>
+          <td>
+            @if (campaign.active) {
+              <span class="badge badge-active">Active</span>
+            } @else {
+              <span class="badge">Inactive</span>
+            }
+          </td>
+          <td class="actions">
+            <button type="button" class="btn" (click)="copyLink(campaign)">Copy link</button>
+            <button type="button" class="btn" (click)="viewEntries(campaign)">Entries</button>
+            <button type="button" class="btn" (click)="toggleActive(campaign)">
+              {{ campaign.active ? 'Deactivate' : 'Activate' }}
+            </button>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</section>
+
+@if (selectedEntries().length) {
+  <section class="card section">
+    <div class="section-header">
+      <h2>Draw entries</h2>
+      <button type="button" class="btn btn-primary" (click)="exportEntriesCsv()">Export CSV</button>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Entry token</th>
+          <th>User</th>
+          <th>Unit</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (entry of selectedEntries(); track entry.id) {
+          <tr>
+            <td><code>{{ entry.entryToken }}</code></td>
+            <td>{{ entry.userEmail }}</td>
+            <td>{{ entry.unitCode }}</td>
+            <td>{{ entry.createdAt | date: 'short' }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </section>
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.html
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.html
@@ -25,7 +25,12 @@
     </label>
     <input type="number" placeholder="Max signups (optional)" [(ngModel)]="maxRedemptions" name="maxRedemptions" />
     <input type="number" placeholder="Min review length" [(ngModel)]="minReviewLength" name="minReviewLength" />
-    <input type="number" placeholder="Max entries per user" [(ngModel)]="maxEntriesPerUser" name="maxEntriesPerUser" />
+    <input type="number" placeholder="Required reviews for entry" [(ngModel)]="requiredReviewCount" name="requiredReviewCount" />
+    <input type="number" placeholder="Max draw entries per user" [(ngModel)]="maxEntriesPerUser" name="maxEntriesPerUser" />
+    <label class="checkbox">
+      <input type="checkbox" [(ngModel)]="requireVerifiedStudent" name="requireVerifiedStudent" />
+      Require verified student
+    </label>
   </div>
   <button type="button" class="btn btn-primary" (click)="createCampaign()">Create campaign</button>
 </section>
@@ -56,6 +61,11 @@
           <td>
             <div><code>{{ campaign.slug }}</code></div>
             <div><code>{{ campaign.code }}</code></div>
+            <div class="subtle">
+              {{ campaign.requiredReviewCount }} review(s) ·
+              {{ campaign.requireVerifiedStudent ? 'verified only' : 'any account' }} ·
+              min {{ campaign.minReviewLength }} chars
+            </div>
           </td>
           <td>
             {{ campaign.startsAt | date: 'mediumDate' }} –

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
@@ -1,0 +1,137 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AdminService } from '../../services/admin.service';
+import { CampaignAdmin, CampaignEntryAdmin } from '../../models/admin.model';
+
+@Component({
+  selector: 'app-campaigns',
+  imports: [FormsModule, DatePipe],
+  templateUrl: './campaigns.component.html',
+  styleUrl: './campaigns.component.css'
+})
+export class CampaignsComponent implements OnInit {
+  private adminService = inject(AdminService);
+
+  campaigns = signal<CampaignAdmin[]>([]);
+  selectedEntries = signal<CampaignEntryAdmin[]>([]);
+  selectedCampaignId = signal<string | null>(null);
+  errorMessage = signal<string | null>(null);
+  successMessage = signal<string | null>(null);
+
+  slug = '';
+  code = '';
+  name = '';
+  prizeDescription = '';
+  startsAt = '';
+  endsAt = '';
+  maxRedemptions: number | null = null;
+  minReviewLength = 50;
+  maxEntriesPerUser = 5;
+
+  ngOnInit(): void {
+    this.refreshCampaigns();
+    this.setDefaultDates();
+  }
+
+  refreshCampaigns(): void {
+    this.adminService.listCampaigns().subscribe({
+      next: (data) => this.campaigns.set(data),
+      error: () => this.errorMessage.set('Failed to load campaigns.')
+    });
+  }
+
+  createCampaign(): void {
+    this.clearMessages();
+
+    this.adminService.createCampaign({
+      slug: this.slug,
+      code: this.code,
+      name: this.name,
+      prizeDescription: this.prizeDescription,
+      startsAt: new Date(this.startsAt).toISOString(),
+      endsAt: new Date(this.endsAt).toISOString(),
+      maxRedemptions: this.maxRedemptions,
+      minReviewLength: this.minReviewLength,
+      maxEntriesPerUser: this.maxEntriesPerUser
+    }).subscribe({
+      next: () => {
+        this.successMessage.set('Campaign created.');
+        this.slug = '';
+        this.code = '';
+        this.name = '';
+        this.prizeDescription = '';
+        this.maxRedemptions = null;
+        this.setDefaultDates();
+        this.refreshCampaigns();
+      },
+      error: (err) => this.errorMessage.set(err.error?.error || 'Failed to create campaign.')
+    });
+  }
+
+  toggleActive(campaign: CampaignAdmin): void {
+    this.clearMessages();
+    this.adminService.setCampaignActive(campaign.id, !campaign.active).subscribe({
+      next: () => {
+        this.successMessage.set(campaign.active ? 'Campaign deactivated.' : 'Campaign activated.');
+        this.refreshCampaigns();
+      },
+      error: () => this.errorMessage.set('Failed to update campaign status.')
+    });
+  }
+
+  viewEntries(campaign: CampaignAdmin): void {
+    this.clearMessages();
+    this.selectedCampaignId.set(campaign.id);
+    this.adminService.listCampaignEntries(campaign.id).subscribe({
+      next: (entries) => this.selectedEntries.set(entries),
+      error: () => this.errorMessage.set('Failed to load campaign entries.')
+    });
+  }
+
+  registrationLink(campaign: CampaignAdmin): string {
+    const origin = typeof window !== 'undefined' ? window.location.origin.replace(':4201', ':4200') : 'https://curtinhonestly.com';
+    return `${origin}/register?ref=${encodeURIComponent(campaign.slug)}&code=${encodeURIComponent(campaign.code)}`;
+  }
+
+  copyLink(campaign: CampaignAdmin): void {
+    navigator.clipboard.writeText(this.registrationLink(campaign)).then(() => {
+      this.successMessage.set('Registration link copied.');
+    }).catch(() => this.errorMessage.set('Could not copy link.'));
+  }
+
+  exportEntriesCsv(): void {
+    const entries = this.selectedEntries();
+    if (!entries.length) {
+      return;
+    }
+
+    const header = 'entryToken,userEmail,unitCode,createdAt';
+    const rows = entries.map(entry =>
+      [entry.entryToken, entry.userEmail, entry.unitCode, entry.createdAt]
+        .map(value => `"${String(value).replace(/"/g, '""')}"`)
+        .join(',')
+    );
+    const csv = [header, ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `campaign-entries-${this.selectedCampaignId()}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  private setDefaultDates(): void {
+    const now = new Date();
+    const end = new Date(now);
+    end.setDate(end.getDate() + 21);
+    this.startsAt = now.toISOString().slice(0, 16);
+    this.endsAt = end.toISOString().slice(0, 16);
+  }
+
+  private clearMessages(): void {
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+  }
+}

--- a/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
+++ b/admin-frontend/src/app/pages/campaigns/campaigns.component.ts
@@ -27,7 +27,9 @@ export class CampaignsComponent implements OnInit {
   endsAt = '';
   maxRedemptions: number | null = null;
   minReviewLength = 50;
-  maxEntriesPerUser = 5;
+  maxEntriesPerUser = 1;
+  requireVerifiedStudent = true;
+  requiredReviewCount = 1;
 
   ngOnInit(): void {
     this.refreshCampaigns();
@@ -53,7 +55,9 @@ export class CampaignsComponent implements OnInit {
       endsAt: new Date(this.endsAt).toISOString(),
       maxRedemptions: this.maxRedemptions,
       minReviewLength: this.minReviewLength,
-      maxEntriesPerUser: this.maxEntriesPerUser
+      maxEntriesPerUser: this.maxEntriesPerUser,
+      requireVerifiedStudent: this.requireVerifiedStudent,
+      requiredReviewCount: this.requiredReviewCount
     }).subscribe({
       next: () => {
         this.successMessage.set('Campaign created.');

--- a/admin-frontend/src/app/services/admin.service.ts
+++ b/admin-frontend/src/app/services/admin.service.ts
@@ -71,6 +71,8 @@ export class AdminService {
     maxRedemptions: number | null;
     minReviewLength: number;
     maxEntriesPerUser: number;
+    requireVerifiedStudent: boolean;
+    requiredReviewCount: number;
   }): Observable<CampaignAdmin> {
     return this.http.post<CampaignAdmin>(`${this.apiUrl}/campaigns`, payload);
   }

--- a/admin-frontend/src/app/services/admin.service.ts
+++ b/admin-frontend/src/app/services/admin.service.ts
@@ -6,6 +6,8 @@ import {
   AdminAnalytics,
   AdminOverview,
   AdminReview,
+  CampaignAdmin,
+  CampaignEntryAdmin,
   PagedReviews,
   UserAdmin
 } from '../models/admin.model';
@@ -53,5 +55,31 @@ export class AdminService {
 
   deleteReview(id: string): Observable<void> {
     return this.http.delete<void>(`${this.apiUrl}/reviews/${id}`);
+  }
+
+  listCampaigns(): Observable<CampaignAdmin[]> {
+    return this.http.get<CampaignAdmin[]>(`${this.apiUrl}/campaigns`);
+  }
+
+  createCampaign(payload: {
+    slug: string;
+    code: string;
+    name: string;
+    prizeDescription: string;
+    startsAt: string;
+    endsAt: string;
+    maxRedemptions: number | null;
+    minReviewLength: number;
+    maxEntriesPerUser: number;
+  }): Observable<CampaignAdmin> {
+    return this.http.post<CampaignAdmin>(`${this.apiUrl}/campaigns`, payload);
+  }
+
+  setCampaignActive(id: string, active: boolean): Observable<CampaignAdmin> {
+    return this.http.patch<CampaignAdmin>(`${this.apiUrl}/campaigns/${id}/active`, { active });
+  }
+
+  listCampaignEntries(id: string): Observable<CampaignEntryAdmin[]> {
+    return this.http.get<CampaignEntryAdmin[]>(`${this.apiUrl}/campaigns/${id}/entries`);
   }
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
@@ -52,6 +52,12 @@ public class Campaign {
     @Column(nullable = false)
     private int maxEntriesPerUser = 5;
 
+    @Column(nullable = false)
+    private boolean requireVerifiedStudent = true;
+
+    @Column(nullable = false)
+    private int requiredReviewCount = 1;
+
     @Column(nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Campaign.java
@@ -1,0 +1,57 @@
+package com.curtinhonestly.backend.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "campaigns")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class Campaign {
+
+    @Id
+    @UuidGenerator
+    private String id;
+
+    @Column(unique = true, nullable = false)
+    private String slug;
+
+    @Column(unique = true, nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(length = 500)
+    private String prizeDescription;
+
+    @Column(nullable = false)
+    private Instant startsAt;
+
+    @Column(nullable = false)
+    private Instant endsAt;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    private Integer maxRedemptions;
+
+    @Column(nullable = false)
+    private int minReviewLength = 50;
+
+    @Column(nullable = false)
+    private int maxEntriesPerUser = 5;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/CampaignEntry.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/CampaignEntry.java
@@ -37,9 +37,18 @@ public class CampaignEntry {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
-    @OneToOne(optional = false)
-    @JoinColumn(name = "review_id", nullable = false, unique = true)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    // The unit whose qualifying review triggered this entry. Kept even if the
+    // review itself is later deleted, so the per-unit re-earn gate in
+    // CampaignService still holds after a delete-and-resubmit cycle.
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "unit_id", nullable = false)
+    private Unit unit;
+
+    // Nullable + SET_NULL: deleting the review must not delete the entry (the
+    // user keeps a token they already earned), only detach it from the review.
+    @OneToOne
+    @JoinColumn(name = "review_id", unique = true)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Review review;
 
     @Column(nullable = false, updatable = false)

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/CampaignEntry.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/CampaignEntry.java
@@ -1,0 +1,47 @@
+package com.curtinhonestly.backend.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "campaign_entries")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+public class CampaignEntry {
+
+    @Id
+    @UuidGenerator
+    private String id;
+
+    @Column(unique = true, nullable = false, length = 16)
+    private String entryToken;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "campaign_id", nullable = false)
+    private Campaign campaign;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "review_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Review review;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
@@ -15,7 +15,10 @@ import java.time.Instant;
 @Entity
 
 // Map to the "reviews" table
-@Table(name = "reviews")
+@Table(
+        name = "reviews",
+        uniqueConstraints = @UniqueConstraint(name = "uk_reviews_user_unit", columnNames = {"user_id", "unit_id"})
+)
 
 // Lombok getters/setters
 @Getter

--- a/backend/src/main/java/com/curtinhonestly/backend/domain/User.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/User.java
@@ -61,6 +61,13 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Review> reviews;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "campaign_id")
+    private Campaign campaign;
+
+    @Column(length = 100)
+    private String registeredViaRef;
+
 }
 
 

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
@@ -14,5 +14,6 @@ public class AccountDTO {
     private String campaignName;
     private String campaignPrizeDescription;
     private Instant campaignEndsAt;
+    private CampaignProgressDTO campaignProgress;
     private List<CampaignEntrySummaryDTO> campaignEntries;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/AccountDTO.java
@@ -3,9 +3,16 @@ package com.curtinhonestly.backend.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.Instant;
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 public class AccountDTO {
     private String email;
     private boolean verifiedStudent;
+    private String campaignName;
+    private String campaignPrizeDescription;
+    private Instant campaignEndsAt;
+    private List<CampaignEntrySummaryDTO> campaignEntries;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
@@ -1,0 +1,25 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignAdminDTO {
+    private String id;
+    private String slug;
+    private String code;
+    private String name;
+    private String prizeDescription;
+    private Instant startsAt;
+    private Instant endsAt;
+    private boolean active;
+    private Integer maxRedemptions;
+    private int minReviewLength;
+    private int maxEntriesPerUser;
+    private long signupCount;
+    private long entryCount;
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignAdminDTO.java
@@ -19,6 +19,8 @@ public class CampaignAdminDTO {
     private Integer maxRedemptions;
     private int minReviewLength;
     private int maxEntriesPerUser;
+    private boolean requireVerifiedStudent;
+    private int requiredReviewCount;
     private long signupCount;
     private long entryCount;
     private Instant createdAt;

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntryAdminDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntryAdminDTO.java
@@ -1,0 +1,16 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignEntryAdminDTO {
+    private String id;
+    private String entryToken;
+    private String userEmail;
+    private String unitCode;
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntrySummaryDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignEntrySummaryDTO.java
@@ -1,0 +1,15 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignEntrySummaryDTO {
+    private String entryToken;
+    private String campaignName;
+    private String unitCode;
+    private Instant createdAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignProgressDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignProgressDTO.java
@@ -1,0 +1,14 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CampaignProgressDTO {
+    private int qualifyingReviews;
+    private int requiredReviews;
+    private int entriesEarned;
+    private int maxEntries;
+    private boolean requireVerifiedStudent;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignValidationDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CampaignValidationDTO.java
@@ -1,0 +1,16 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CampaignValidationDTO {
+    private boolean valid;
+    private String message;
+    private String campaignName;
+    private String prizeDescription;
+    private Instant endsAt;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
@@ -1,0 +1,14 @@
+package com.curtinhonestly.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@AllArgsConstructor
+public class CreateReviewResponseDTO {
+    private ReviewDTO review;
+    private String campaignEntryToken;
+    private String campaignName;
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/CreateReviewResponseDTO.java
@@ -11,4 +11,5 @@ public class CreateReviewResponseDTO {
     private ReviewDTO review;
     private String campaignEntryToken;
     private String campaignName;
+    private CampaignProgressDTO campaignProgress;
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/MyReviewDTO.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/MyReviewDTO.java
@@ -7,7 +7,12 @@ public record MyReviewDTO(
         String unitCode,
         String unitName,
         int rating,
+        Integer finalGrade,
         String reviewText,
         String semesterTaken,
+        String professor,
+        int workload,
+        boolean hasExam,
+        boolean wouldTakeAgain,
         Instant createdAt
 ) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/mapper/ReviewMapper.java
@@ -38,8 +38,13 @@ public class ReviewMapper {
                 unitCode,
                 unitName,
                 review.getRating(),
+                review.getFinalGrade(),
                 review.getReviewText(),
                 review.getSemesterTaken(),
+                review.getProfessor(),
+                review.getWorkload(),
+                review.isHasExam(),
+                review.isWouldTakeAgain(),
                 review.getCreatedAt()
         );
     }

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignEntryRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignEntryRepo.java
@@ -14,8 +14,7 @@ public interface CampaignEntryRepo extends JpaRepository<CampaignEntry, String> 
 
     @Query("""
             SELECT e FROM CampaignEntry e
-            JOIN FETCH e.review r
-            JOIN FETCH r.unit
+            JOIN FETCH e.unit
             JOIN FETCH e.campaign
             WHERE e.user.id = :userId
             ORDER BY e.createdAt DESC
@@ -24,8 +23,7 @@ public interface CampaignEntryRepo extends JpaRepository<CampaignEntry, String> 
 
     @Query("""
             SELECT e FROM CampaignEntry e
-            JOIN FETCH e.review r
-            JOIN FETCH r.unit
+            JOIN FETCH e.unit
             JOIN FETCH e.user
             WHERE e.campaign.id = :campaignId
             ORDER BY e.createdAt DESC
@@ -33,5 +31,5 @@ public interface CampaignEntryRepo extends JpaRepository<CampaignEntry, String> 
     List<CampaignEntry> findByCampaign_IdOrderByCreatedAtDesc(@Param("campaignId") String campaignId);
 
     Optional<CampaignEntry> findByEntryTokenIgnoreCase(String entryToken);
-    boolean existsByReview_Id(String reviewId);
+    boolean existsByCampaign_IdAndUser_IdAndUnit_Id(String campaignId, String userId, String unitId);
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignEntryRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignEntryRepo.java
@@ -1,0 +1,37 @@
+package com.curtinhonestly.backend.repo;
+
+import com.curtinhonestly.backend.domain.CampaignEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CampaignEntryRepo extends JpaRepository<CampaignEntry, String> {
+    long countByCampaign_IdAndUser_Id(String campaignId, String userId);
+    long countByCampaign_Id(String campaignId);
+
+    @Query("""
+            SELECT e FROM CampaignEntry e
+            JOIN FETCH e.review r
+            JOIN FETCH r.unit
+            JOIN FETCH e.campaign
+            WHERE e.user.id = :userId
+            ORDER BY e.createdAt DESC
+            """)
+    List<CampaignEntry> findByUser_IdOrderByCreatedAtDesc(@Param("userId") String userId);
+
+    @Query("""
+            SELECT e FROM CampaignEntry e
+            JOIN FETCH e.review r
+            JOIN FETCH r.unit
+            JOIN FETCH e.user
+            WHERE e.campaign.id = :campaignId
+            ORDER BY e.createdAt DESC
+            """)
+    List<CampaignEntry> findByCampaign_IdOrderByCreatedAtDesc(@Param("campaignId") String campaignId);
+
+    Optional<CampaignEntry> findByEntryTokenIgnoreCase(String entryToken);
+    boolean existsByReview_Id(String reviewId);
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignRepo.java
@@ -1,7 +1,11 @@
 package com.curtinhonestly.backend.repo;
 
 import com.curtinhonestly.backend.domain.Campaign;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +14,11 @@ public interface CampaignRepo extends JpaRepository<Campaign, String> {
     Optional<Campaign> findBySlugIgnoreCase(String slug);
     Optional<Campaign> findByCodeIgnoreCase(String code);
     List<Campaign> findAllByOrderByCreatedAtDesc();
+
+    // Locks the campaign row for the duration of the caller's transaction, so a
+    // maxRedemptions count-and-insert can't race with a concurrent registration
+    // on the last remaining slot.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Campaign c WHERE c.id = :id")
+    Optional<Campaign> findByIdForUpdate(@Param("id") String id);
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/CampaignRepo.java
@@ -1,0 +1,13 @@
+package com.curtinhonestly.backend.repo;
+
+import com.curtinhonestly.backend.domain.Campaign;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CampaignRepo extends JpaRepository<Campaign, String> {
+    Optional<Campaign> findBySlugIgnoreCase(String slug);
+    Optional<Campaign> findByCodeIgnoreCase(String code);
+    List<Campaign> findAllByOrderByCreatedAtDesc();
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
@@ -13,6 +13,7 @@ public interface ReviewRepo extends JpaRepository<Review, String> {
     Optional<Review> findById(String id);
     List<Review> findByUnit_Id(String unitId);
     List<Review> findByUser_IdOrderByCreatedAtDesc(String userId);
+    boolean existsByUser_IdAndUnit_Id(String userId, String unitId);
     long countByCreatedAtAfter(Instant since);
     List<Review> findByCreatedAtAfter(Instant since);
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/UserRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/UserRepo.java
@@ -11,4 +11,5 @@ public interface UserRepo extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
     long countByCreatedAtAfter(Instant since);
     List<User> findByCreatedAtAfter(Instant since);
+    long countByCampaign_Id(String campaignId);
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
@@ -3,6 +3,7 @@ package com.curtinhonestly.backend.resource;
 import com.curtinhonestly.backend.dto.*;
 import com.curtinhonestly.backend.security.SecurityConstants;
 import com.curtinhonestly.backend.service.AdminService;
+import com.curtinhonestly.backend.service.CampaignService;
 import com.curtinhonestly.backend.service.ReviewService;
 import com.curtinhonestly.backend.service.UnitAggregateService;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.List;
 
 @RestController
@@ -22,6 +24,7 @@ public class AdminResource {
     private final AdminService adminService;
     private final ReviewService reviewService;
     private final UnitAggregateService unitAggregateService;
+    private final CampaignService campaignService;
 
     @GetMapping("/stats/overview")
     public ResponseEntity<AdminOverviewDTO> getOverview() {
@@ -83,5 +86,51 @@ public class AdminResource {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/campaigns")
+    public ResponseEntity<List<CampaignAdminDTO>> listCampaigns() {
+        return ResponseEntity.ok(campaignService.listCampaigns());
+    }
+
+    @PostMapping("/campaigns")
+    public ResponseEntity<CampaignAdminDTO> createCampaign(@RequestBody CreateCampaignRequest request) {
+        return ResponseEntity.ok(campaignService.createCampaign(
+                request.slug(),
+                request.code(),
+                request.name(),
+                request.prizeDescription(),
+                request.startsAt(),
+                request.endsAt(),
+                request.maxRedemptions(),
+                request.minReviewLength(),
+                request.maxEntriesPerUser()
+        ));
+    }
+
+    @PatchMapping("/campaigns/{id}/active")
+    public ResponseEntity<CampaignAdminDTO> setCampaignActive(
+            @PathVariable String id,
+            @RequestBody SetCampaignActiveRequest request) {
+        return ResponseEntity.ok(campaignService.setCampaignActive(id, request.active()));
+    }
+
+    @GetMapping("/campaigns/{id}/entries")
+    public ResponseEntity<List<CampaignEntryAdminDTO>> listCampaignEntries(@PathVariable String id) {
+        return ResponseEntity.ok(campaignService.listEntriesForCampaign(id));
+    }
+
     public record CreateUserRequest(String email, String password, boolean admin) {}
+
+    public record CreateCampaignRequest(
+            String slug,
+            String code,
+            String name,
+            String prizeDescription,
+            Instant startsAt,
+            Instant endsAt,
+            Integer maxRedemptions,
+            int minReviewLength,
+            int maxEntriesPerUser
+    ) {}
+
+    public record SetCampaignActiveRequest(boolean active) {}
 }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AdminResource.java
@@ -102,7 +102,9 @@ public class AdminResource {
                 request.endsAt(),
                 request.maxRedemptions(),
                 request.minReviewLength(),
-                request.maxEntriesPerUser()
+                request.maxEntriesPerUser(),
+                request.requireVerifiedStudent(),
+                request.requiredReviewCount()
         ));
     }
 
@@ -129,7 +131,9 @@ public class AdminResource {
             Instant endsAt,
             Integer maxRedemptions,
             int minReviewLength,
-            int maxEntriesPerUser
+            int maxEntriesPerUser,
+            boolean requireVerifiedStudent,
+            int requiredReviewCount
     ) {}
 
     public record SetCampaignActiveRequest(boolean active) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
@@ -98,6 +98,7 @@ public class AuthController {
                 campaign != null ? campaign.getName() : null,
                 campaign != null ? campaign.getPrizeDescription() : null,
                 campaign != null ? campaign.getEndsAt() : null,
+                campaignService.getCampaignProgress(user),
                 entries
         ));
     }

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
@@ -1,6 +1,5 @@
 package com.curtinhonestly.backend.resource;
 
-import com.curtinhonestly.backend.domain.Campaign;
 import com.curtinhonestly.backend.domain.User;
 import com.curtinhonestly.backend.dto.AccountDTO;
 import com.curtinhonestly.backend.dto.ErrorResponse;
@@ -38,18 +37,8 @@ public class AuthController {
     public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) {
         log.info("Registration attempt for email: {}", request.email());
 
-        Campaign campaign = null;
-        if (hasCampaignAttribution(request)) {
-            campaign = campaignService.resolveCampaignForRegistration(request.ref(), request.promoCode())
-                    .orElseThrow(() -> new IllegalArgumentException("Campaign not found. Check your referral link or promo code."));
-
-            var validation = campaignService.validateCampaign(request.ref(), request.promoCode());
-            if (!validation.isValid()) {
-                throw new IllegalArgumentException(validation.getMessage());
-            }
-        }
-
-        User user = userService.createUser(request.email(), request.password(), campaign, request.ref());
+        User user = campaignService.registerUserWithCampaign(
+                request.email(), request.password(), request.ref(), request.promoCode());
         String token = jwtUtil.generateToken(
                 user.getEmail(),
                 user.getRoles().stream().map(Enum::name).toList()
@@ -143,11 +132,6 @@ public class AuthController {
                 user.getRoles().stream().map(Enum::name).toList()
         );
         return ResponseEntity.ok(new JwtResponse(token, user.isVerifiedStudent()));
-    }
-
-    private boolean hasCampaignAttribution(RegisterRequest request) {
-        return (request.ref() != null && !request.ref().isBlank())
-                || (request.promoCode() != null && !request.promoCode().isBlank());
     }
 
     public record RegisterRequest(@NotBlank @Email String email, @NotBlank String password, String ref, String promoCode) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/AuthController.java
@@ -1,9 +1,12 @@
 package com.curtinhonestly.backend.resource;
 
+import com.curtinhonestly.backend.domain.Campaign;
 import com.curtinhonestly.backend.domain.User;
 import com.curtinhonestly.backend.dto.AccountDTO;
 import com.curtinhonestly.backend.dto.ErrorResponse;
+import com.curtinhonestly.backend.dto.CampaignEntrySummaryDTO;
 import com.curtinhonestly.backend.security.JwtUtil;
+import com.curtinhonestly.backend.service.CampaignService;
 import com.curtinhonestly.backend.service.UserService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -18,6 +21,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -27,12 +32,24 @@ public class AuthController {
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
     private final UserService userService;
+    private final CampaignService campaignService;
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) {
         log.info("Registration attempt for email: {}", request.email());
 
-        User user = userService.createUser(request.email(), request.password());
+        Campaign campaign = null;
+        if (hasCampaignAttribution(request)) {
+            campaign = campaignService.resolveCampaignForRegistration(request.ref(), request.promoCode())
+                    .orElseThrow(() -> new IllegalArgumentException("Campaign not found. Check your referral link or promo code."));
+
+            var validation = campaignService.validateCampaign(request.ref(), request.promoCode());
+            if (!validation.isValid()) {
+                throw new IllegalArgumentException(validation.getMessage());
+            }
+        }
+
+        User user = userService.createUser(request.email(), request.password(), campaign, request.ref());
         String token = jwtUtil.generateToken(
                 user.getEmail(),
                 user.getRoles().stream().map(Enum::name).toList()
@@ -72,7 +89,17 @@ public class AuthController {
     public ResponseEntity<AccountDTO> getCurrentAccount() {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         User user = userService.getUserByEmail(email);
-        return ResponseEntity.ok(new AccountDTO(user.getEmail(), user.isVerifiedStudent()));
+        var campaign = user.getCampaign();
+        List<CampaignEntrySummaryDTO> entries = campaignService.getEntriesForUser(user);
+
+        return ResponseEntity.ok(new AccountDTO(
+                user.getEmail(),
+                user.isVerifiedStudent(),
+                campaign != null ? campaign.getName() : null,
+                campaign != null ? campaign.getPrizeDescription() : null,
+                campaign != null ? campaign.getEndsAt() : null,
+                entries
+        ));
     }
 
     @PatchMapping("/me")
@@ -117,7 +144,12 @@ public class AuthController {
         return ResponseEntity.ok(new JwtResponse(token, user.isVerifiedStudent()));
     }
 
-    public record RegisterRequest(@NotBlank @Email String email, @NotBlank String password) {}
+    private boolean hasCampaignAttribution(RegisterRequest request) {
+        return (request.ref() != null && !request.ref().isBlank())
+                || (request.promoCode() != null && !request.promoCode().isBlank());
+    }
+
+    public record RegisterRequest(@NotBlank @Email String email, @NotBlank String password, String ref, String promoCode) {}
     public record LoginRequest(String email, String password) {}
     public record VerifyStudentRequest(String studentEmail, String password) {}
     public record UpdateEmailRequest(String newEmail, String password) {}

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/CampaignResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/CampaignResource.java
@@ -1,0 +1,25 @@
+package com.curtinhonestly.backend.resource;
+
+import com.curtinhonestly.backend.dto.CampaignValidationDTO;
+import com.curtinhonestly.backend.service.CampaignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/campaigns")
+@RequiredArgsConstructor
+public class CampaignResource {
+
+    private final CampaignService campaignService;
+
+    @GetMapping("/validate")
+    public ResponseEntity<CampaignValidationDTO> validateCampaign(
+            @RequestParam(required = false) String ref,
+            @RequestParam(required = false) String code) {
+        return ResponseEntity.ok(campaignService.validateCampaign(ref, code));
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.curtinhonestly.backend.resource;
 
 import com.curtinhonestly.backend.dto.ErrorResponse;
+import com.curtinhonestly.backend.service.CampaignEntryTokenExhaustedException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -16,6 +18,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
     public ResponseEntity<ErrorResponse> handleBadRequest(RuntimeException ex) {
         return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(CampaignEntryTokenExhaustedException.class)
+    public ResponseEntity<ErrorResponse> handleServiceUnavailable(CampaignEntryTokenExhaustedException ex) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new ErrorResponse(ex.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
@@ -2,6 +2,7 @@ package com.curtinhonestly.backend.resource;
 
 import com.curtinhonestly.backend.dto.MyReviewDTO;
 import com.curtinhonestly.backend.dto.ReviewCreateRequest;
+import com.curtinhonestly.backend.dto.CreateReviewResponseDTO;
 import com.curtinhonestly.backend.dto.ReviewDTO;
 import com.curtinhonestly.backend.mapper.ReviewMapper;
 import com.curtinhonestly.backend.domain.Review;
@@ -38,9 +39,20 @@ public class ReviewResource {
     @PostMapping
     @PreAuthorize(SecurityConstants.HAS_ROLE_USER)
     public ResponseEntity<?> createReview(@Valid @RequestBody ReviewCreateRequest request) {
-        Review savedReview = reviewService.createReview(request);
-        return ResponseEntity.created(URI.create("/reviews/" + savedReview.getId()))
-                .body(ReviewMapper.mapToDTO(savedReview));
+        ReviewService.ReviewCreationResult result = reviewService.createReviewWithCampaignEntry(request);
+        Review savedReview = result.review();
+        ReviewDTO reviewDto = ReviewMapper.mapToDTO(savedReview);
+
+        String entryToken = null;
+        String campaignName = null;
+        if (result.campaignEntry().isPresent()) {
+            var entry = result.campaignEntry().get();
+            entryToken = entry.getEntryToken();
+            campaignName = entry.getCampaign().getName();
+        }
+
+        CreateReviewResponseDTO response = new CreateReviewResponseDTO(reviewDto, entryToken, campaignName);
+        return ResponseEntity.created(URI.create("/reviews/" + savedReview.getId())).body(response);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/resource/ReviewResource.java
@@ -1,8 +1,8 @@
 package com.curtinhonestly.backend.resource;
 
+import com.curtinhonestly.backend.dto.CreateReviewResponseDTO;
 import com.curtinhonestly.backend.dto.MyReviewDTO;
 import com.curtinhonestly.backend.dto.ReviewCreateRequest;
-import com.curtinhonestly.backend.dto.CreateReviewResponseDTO;
 import com.curtinhonestly.backend.dto.ReviewDTO;
 import com.curtinhonestly.backend.mapper.ReviewMapper;
 import com.curtinhonestly.backend.domain.Review;
@@ -51,7 +51,7 @@ public class ReviewResource {
             campaignName = entry.getCampaign().getName();
         }
 
-        CreateReviewResponseDTO response = new CreateReviewResponseDTO(reviewDto, entryToken, campaignName);
+        CreateReviewResponseDTO response = new CreateReviewResponseDTO(reviewDto, entryToken, campaignName, result.campaignProgress());
         return ResponseEntity.created(URI.create("/reviews/" + savedReview.getId())).body(response);
     }
 

--- a/backend/src/main/java/com/curtinhonestly/backend/security/RateLimitFilter.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/RateLimitFilter.java
@@ -1,0 +1,58 @@
+package com.curtinhonestly.backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+// IP-keyed rate limiting for selected public endpoints. Add an entry to
+// LIMITS to cover a new route/method - the mechanism (IP extraction, sliding
+// window, 429 response) is shared, not re-implemented per endpoint.
+@Component
+@RequiredArgsConstructor
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private record Limit(String method, String pathPrefix, int maxRequests, Duration window) {}
+
+    private static final List<Limit> LIMITS = List.of(
+            new Limit("GET", "/campaigns/validate", 10, Duration.ofMinutes(1))
+    );
+
+    private final RateLimiter rateLimiter;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        Optional<Limit> limit = LIMITS.stream()
+                .filter(l -> l.method().equalsIgnoreCase(request.getMethod()) && request.getRequestURI().startsWith(l.pathPrefix()))
+                .findFirst();
+
+        if (limit.isPresent()) {
+            String key = clientIp(request) + ":" + limit.get().pathPrefix();
+            if (!rateLimiter.tryAcquire(key, limit.get().maxRequests(), limit.get().window())) {
+                response.setStatus(429);
+                response.setContentType("application/json");
+                response.getWriter().write("{\"error\":\"Too many requests. Please try again later.\"}");
+                return;
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/security/RateLimiter.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/RateLimiter.java
@@ -1,0 +1,35 @@
+package com.curtinhonestly.backend.security;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentHashMap;
+
+// Generic in-memory sliding-window rate limiter, keyed by any caller-supplied
+// string (e.g. "ip:path"). Not shared across instances - fine for a single
+// backend replica; would need a shared store (Redis etc.) behind a load balancer.
+@Component
+public class RateLimiter {
+
+    private final ConcurrentHashMap<String, Deque<Instant>> requestLog = new ConcurrentHashMap<>();
+
+    public boolean tryAcquire(String key, int maxRequests, Duration window) {
+        Instant now = Instant.now();
+        Instant windowStart = now.minus(window);
+
+        Deque<Instant> timestamps = requestLog.computeIfAbsent(key, k -> new ArrayDeque<>());
+        synchronized (timestamps) {
+            while (!timestamps.isEmpty() && timestamps.peekFirst().isBefore(windowStart)) {
+                timestamps.pollFirst();
+            }
+            if (timestamps.size() >= maxRequests) {
+                return false;
+            }
+            timestamps.addLast(now);
+            return true;
+        }
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final RateLimitFilter rateLimitFilter;
 
     @Value("${app.cors.allowed-origins}")
     private List<String> corsAllowedOrigins;
@@ -78,6 +79,7 @@ public class SecurityConfig {
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(rateLimitFilter, JwtAuthenticationFilter.class)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable);
 

--- a/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/security/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/units", "/units/**").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/auth/register", "/auth/login").permitAll()
+                        .requestMatchers("/campaigns/validate").permitAll()
                         .requestMatchers("/auth/me", "/auth/verify-student").authenticated()
                         .requestMatchers("/error").permitAll()
 

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignEntryTokenExhaustedException.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignEntryTokenExhaustedException.java
@@ -1,0 +1,10 @@
+package com.curtinhonestly.backend.service;
+
+// Thrown when CampaignService can't find an unused entry token after several
+// attempts. Distinct from IllegalStateException so GlobalExceptionHandler can
+// map it to 503 (retry later) instead of 400 (client's request was invalid).
+public class CampaignEntryTokenExhaustedException extends RuntimeException {
+    public CampaignEntryTokenExhaustedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -36,9 +36,34 @@ public class CampaignService {
     private final CampaignEntryRepo campaignEntryRepo;
     private final UserRepo userRepo;
     private final ReviewRepo reviewRepo;
+    private final UserService userService;
     private final SecureRandom secureRandom = new SecureRandom();
 
     public record CampaignAwardResult(Optional<CampaignEntry> newEntry, CampaignProgressDTO progress) {}
+
+    // Resolves attribution, locks the campaign row, re-validates its state under
+    // that lock, then creates the user - all in this one transaction. Holding the
+    // lock across the whole count-and-insert (not just the initial read) is what
+    // stops two concurrent registrations from both winning the last redemption slot.
+    public User registerUserWithCampaign(String email, String password, String ref, String promoCode) {
+        boolean hasAttribution = normalize(ref).isPresent() || normalize(promoCode).isPresent();
+        if (!hasAttribution) {
+            return userService.createUser(email, password, null, null);
+        }
+
+        Campaign resolved = resolveCampaignForRegistration(ref, promoCode)
+                .orElseThrow(() -> new IllegalArgumentException("Campaign not found. Check your referral link or promo code."));
+
+        Campaign locked = campaignRepo.findByIdForUpdate(resolved.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Campaign not found. Check your referral link or promo code."));
+
+        String stateError = validateCampaignState(locked, true);
+        if (stateError != null) {
+            throw new IllegalArgumentException(stateError);
+        }
+
+        return userService.createUser(email, password, locked, ref);
+    }
 
     public Optional<Campaign> resolveCampaignForRegistration(String ref, String promoCode) {
         Campaign byRef = normalize(ref)

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -104,6 +104,14 @@ public class CampaignService {
             return new CampaignAwardResult(Optional.empty(), progress);
         }
 
+        // A unit whose review already produced an entry can't trigger another one.
+        // Without this, deleting and resubmitting a review for the same unit would
+        // free up the (user_id, unit_id) slot and let qualifyingCount recount it,
+        // looping indefinitely for unlimited entries.
+        if (campaignEntryRepo.existsByCampaign_IdAndUser_IdAndUnit_Id(campaign.getId(), user.getId(), triggeringReview.getUnit().getId())) {
+            return new CampaignAwardResult(Optional.empty(), progress);
+        }
+
         long qualifyingCount = countQualifyingReviews(user, campaign);
         int requiredReviewCount = Math.max(1, campaign.getRequiredReviewCount());
         int maxEntriesPerUser = Math.max(1, campaign.getMaxEntriesPerUser());
@@ -112,10 +120,11 @@ public class CampaignService {
         long entriesToCreate = entriesShouldHave - existingEntries;
 
         Optional<CampaignEntry> newEntry = Optional.empty();
-        for (long i = 0; i < entriesToCreate; i++) {
+        if (entriesToCreate > 0) {
             CampaignEntry entry = new CampaignEntry();
             entry.setCampaign(campaign);
             entry.setUser(user);
+            entry.setUnit(triggeringReview.getUnit());
             entry.setReview(triggeringReview);
             entry.setEntryToken(generateUniqueEntryToken());
             CampaignEntry saved = campaignEntryRepo.save(entry);
@@ -132,7 +141,7 @@ public class CampaignService {
                 .map(entry -> new CampaignEntrySummaryDTO(
                         entry.getEntryToken(),
                         entry.getCampaign().getName(),
-                        entry.getReview().getUnit().getCode(),
+                        entry.getUnit().getCode(),
                         entry.getCreatedAt()
                 ))
                 .toList();
@@ -214,7 +223,7 @@ public class CampaignService {
                         entry.getId(),
                         entry.getEntryToken(),
                         entry.getUser().getEmail(),
-                        entry.getReview().getUnit().getCode(),
+                        entry.getUnit().getCode(),
                         entry.getCreatedAt()
                 ))
                 .toList();

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -81,16 +81,21 @@ public class CampaignService {
         return Optional.ofNullable(campaign);
     }
 
+    // Not-found, expired, not-started, and limit-reached all return this same
+    // response so an unauthenticated caller can't enumerate which promo codes
+    // exist vs. which have simply run out (audit #10).
+    private static final String INVALID_CAMPAIGN_MESSAGE = "This referral link or promo code is invalid or no longer available.";
+
     public CampaignValidationDTO validateCampaign(String ref, String promoCode) {
         Optional<Campaign> campaignOpt = resolveCampaignForRegistration(ref, promoCode);
         if (campaignOpt.isEmpty()) {
-            return new CampaignValidationDTO(false, "Campaign not found.", null, null, null);
+            return new CampaignValidationDTO(false, INVALID_CAMPAIGN_MESSAGE, null, null, null);
         }
 
         Campaign campaign = campaignOpt.get();
         String message = validateCampaignState(campaign, true);
         if (message != null) {
-            return new CampaignValidationDTO(false, message, campaign.getName(), campaign.getPrizeDescription(), campaign.getEndsAt());
+            return new CampaignValidationDTO(false, INVALID_CAMPAIGN_MESSAGE, null, null, null);
         }
 
         return new CampaignValidationDTO(

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -335,7 +335,8 @@ public class CampaignService {
                 return token;
             }
         }
-        throw new IllegalStateException("Unable to generate a unique campaign entry token.");
+        log.error("Failed to generate a unique campaign entry token after {} attempts", 10);
+        throw new CampaignEntryTokenExhaustedException("Unable to generate a unique entry token right now. Please try again.");
     }
 
     private String randomTokenSuffix() {

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -7,9 +7,11 @@ import com.curtinhonestly.backend.domain.User;
 import com.curtinhonestly.backend.dto.CampaignAdminDTO;
 import com.curtinhonestly.backend.dto.CampaignEntryAdminDTO;
 import com.curtinhonestly.backend.dto.CampaignEntrySummaryDTO;
+import com.curtinhonestly.backend.dto.CampaignProgressDTO;
 import com.curtinhonestly.backend.dto.CampaignValidationDTO;
 import com.curtinhonestly.backend.repo.CampaignEntryRepo;
 import com.curtinhonestly.backend.repo.CampaignRepo;
+import com.curtinhonestly.backend.repo.ReviewRepo;
 import com.curtinhonestly.backend.repo.UserRepo;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +35,10 @@ public class CampaignService {
     private final CampaignRepo campaignRepo;
     private final CampaignEntryRepo campaignEntryRepo;
     private final UserRepo userRepo;
+    private final ReviewRepo reviewRepo;
     private final SecureRandom secureRandom = new SecureRandom();
+
+    public record CampaignAwardResult(Optional<CampaignEntry> newEntry, CampaignProgressDTO progress) {}
 
     public Optional<Campaign> resolveCampaignForRegistration(String ref, String promoCode) {
         Campaign byRef = normalize(ref)
@@ -72,43 +77,54 @@ public class CampaignService {
         );
     }
 
-    public Optional<CampaignEntry> tryCreateEntryForReview(User user, Review review) {
-        if (user.getCampaign() == null || user.isBanned() || !user.isVerifiedStudent()) {
-            return Optional.empty();
+    public CampaignProgressDTO getCampaignProgress(User user) {
+        if (user.getCampaign() == null) {
+            return null;
+        }
+        return buildProgress(user, user.getCampaign());
+    }
+
+    public CampaignAwardResult tryAwardCampaignEntries(User user, Review triggeringReview) {
+        if (user.getCampaign() == null || user.isBanned()) {
+            return new CampaignAwardResult(Optional.empty(), null);
         }
 
         Campaign campaign = user.getCampaign();
-        if (!isWithinWindow(campaign, review.getCreatedAt())) {
-            return Optional.empty();
+        CampaignProgressDTO progress = buildProgress(user, campaign);
+
+        if (campaign.isRequireVerifiedStudent() && !user.isVerifiedStudent()) {
+            return new CampaignAwardResult(Optional.empty(), progress);
         }
 
-        String validationMessage = validateCampaignState(campaign, false);
-        if (validationMessage != null) {
-            return Optional.empty();
+        if (!reviewQualifies(triggeringReview, campaign)) {
+            return new CampaignAwardResult(Optional.empty(), progress);
         }
 
-        if (review.getReviewText() == null || review.getReviewText().trim().length() < campaign.getMinReviewLength()) {
-            return Optional.empty();
+        if (validateCampaignState(campaign, false) != null) {
+            return new CampaignAwardResult(Optional.empty(), progress);
         }
 
-        if (campaignEntryRepo.existsByReview_Id(review.getId())) {
-            return Optional.empty();
-        }
-
+        long qualifyingCount = countQualifyingReviews(user, campaign);
+        int requiredReviewCount = Math.max(1, campaign.getRequiredReviewCount());
+        int maxEntriesPerUser = Math.max(1, campaign.getMaxEntriesPerUser());
+        long entriesShouldHave = Math.min(qualifyingCount / requiredReviewCount, maxEntriesPerUser);
         long existingEntries = campaignEntryRepo.countByCampaign_IdAndUser_Id(campaign.getId(), user.getId());
-        if (existingEntries >= campaign.getMaxEntriesPerUser()) {
-            return Optional.empty();
+        long entriesToCreate = entriesShouldHave - existingEntries;
+
+        Optional<CampaignEntry> newEntry = Optional.empty();
+        for (long i = 0; i < entriesToCreate; i++) {
+            CampaignEntry entry = new CampaignEntry();
+            entry.setCampaign(campaign);
+            entry.setUser(user);
+            entry.setReview(triggeringReview);
+            entry.setEntryToken(generateUniqueEntryToken());
+            CampaignEntry saved = campaignEntryRepo.save(entry);
+            newEntry = Optional.of(saved);
+            log.info("Campaign entry {} created for user {} on review {}", saved.getEntryToken(), user.getId(), triggeringReview.getId());
         }
 
-        CampaignEntry entry = new CampaignEntry();
-        entry.setCampaign(campaign);
-        entry.setUser(user);
-        entry.setReview(review);
-        entry.setEntryToken(generateUniqueEntryToken());
-
-        CampaignEntry saved = campaignEntryRepo.save(entry);
-        log.info("Campaign entry {} created for user {} on review {}", saved.getEntryToken(), user.getId(), review.getId());
-        return Optional.of(saved);
+        progress = buildProgress(user, campaign);
+        return new CampaignAwardResult(newEntry, progress);
     }
 
     public List<CampaignEntrySummaryDTO> getEntriesForUser(User user) {
@@ -137,7 +153,9 @@ public class CampaignService {
             Instant endsAt,
             Integer maxRedemptions,
             int minReviewLength,
-            int maxEntriesPerUser
+            int maxEntriesPerUser,
+            boolean requireVerifiedStudent,
+            int requiredReviewCount
     ) {
         String normalizedSlug = requireNormalized(slug, "Campaign slug");
         String normalizedCode = requireNormalized(code, "Promo code").toUpperCase();
@@ -156,7 +174,10 @@ public class CampaignService {
             minReviewLength = 50;
         }
         if (maxEntriesPerUser <= 0) {
-            maxEntriesPerUser = 5;
+            maxEntriesPerUser = 1;
+        }
+        if (requiredReviewCount <= 0) {
+            requiredReviewCount = 1;
         }
 
         Campaign campaign = new Campaign();
@@ -169,6 +190,8 @@ public class CampaignService {
         campaign.setMaxRedemptions(maxRedemptions);
         campaign.setMinReviewLength(minReviewLength);
         campaign.setMaxEntriesPerUser(maxEntriesPerUser);
+        campaign.setRequireVerifiedStudent(requireVerifiedStudent);
+        campaign.setRequiredReviewCount(requiredReviewCount);
         campaign.setActive(true);
 
         return toAdminDTO(campaignRepo.save(campaign));
@@ -197,6 +220,35 @@ public class CampaignService {
                 .toList();
     }
 
+    private long countQualifyingReviews(User user, Campaign campaign) {
+        return reviewRepo.findByUser_IdOrderByCreatedAtDesc(user.getId()).stream()
+                .filter(review -> reviewQualifies(review, campaign))
+                .count();
+    }
+
+    private boolean reviewQualifies(Review review, Campaign campaign) {
+        if (!isWithinWindow(campaign, review.getCreatedAt())) {
+            return false;
+        }
+        return review.getReviewText() != null
+                && review.getReviewText().trim().length() >= campaign.getMinReviewLength();
+    }
+
+    private CampaignProgressDTO buildProgress(User user, Campaign campaign) {
+        long qualifyingReviews = countQualifyingReviews(user, campaign);
+        int requiredReviewCount = Math.max(1, campaign.getRequiredReviewCount());
+        int maxEntriesPerUser = Math.max(1, campaign.getMaxEntriesPerUser());
+        long entriesEarned = Math.min(qualifyingReviews / requiredReviewCount, maxEntriesPerUser);
+
+        return new CampaignProgressDTO(
+                (int) qualifyingReviews,
+                requiredReviewCount,
+                (int) entriesEarned,
+                maxEntriesPerUser,
+                campaign.isRequireVerifiedStudent()
+        );
+    }
+
     private CampaignAdminDTO toAdminDTO(Campaign campaign) {
         return new CampaignAdminDTO(
                 campaign.getId(),
@@ -210,6 +262,8 @@ public class CampaignService {
                 campaign.getMaxRedemptions(),
                 campaign.getMinReviewLength(),
                 campaign.getMaxEntriesPerUser(),
+                campaign.isRequireVerifiedStudent(),
+                campaign.getRequiredReviewCount(),
                 userRepo.countByCampaign_Id(campaign.getId()),
                 campaignEntryRepo.countByCampaign_Id(campaign.getId()),
                 campaign.getCreatedAt()

--- a/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/CampaignService.java
@@ -1,0 +1,272 @@
+package com.curtinhonestly.backend.service;
+
+import com.curtinhonestly.backend.domain.Campaign;
+import com.curtinhonestly.backend.domain.CampaignEntry;
+import com.curtinhonestly.backend.domain.Review;
+import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.dto.CampaignAdminDTO;
+import com.curtinhonestly.backend.dto.CampaignEntryAdminDTO;
+import com.curtinhonestly.backend.dto.CampaignEntrySummaryDTO;
+import com.curtinhonestly.backend.dto.CampaignValidationDTO;
+import com.curtinhonestly.backend.repo.CampaignEntryRepo;
+import com.curtinhonestly.backend.repo.CampaignRepo;
+import com.curtinhonestly.backend.repo.UserRepo;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(rollbackOn = Exception.class)
+public class CampaignService {
+
+    private static final String TOKEN_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final int TOKEN_SUFFIX_LENGTH = 8;
+
+    private final CampaignRepo campaignRepo;
+    private final CampaignEntryRepo campaignEntryRepo;
+    private final UserRepo userRepo;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public Optional<Campaign> resolveCampaignForRegistration(String ref, String promoCode) {
+        Campaign byRef = normalize(ref)
+                .flatMap(campaignRepo::findBySlugIgnoreCase)
+                .orElse(null);
+        Campaign byCode = normalize(promoCode)
+                .flatMap(campaignRepo::findByCodeIgnoreCase)
+                .orElse(null);
+
+        if (byRef != null && byCode != null && !byRef.getId().equals(byCode.getId())) {
+            throw new IllegalArgumentException("Referral link and promo code belong to different campaigns.");
+        }
+
+        Campaign campaign = byRef != null ? byRef : byCode;
+        return Optional.ofNullable(campaign);
+    }
+
+    public CampaignValidationDTO validateCampaign(String ref, String promoCode) {
+        Optional<Campaign> campaignOpt = resolveCampaignForRegistration(ref, promoCode);
+        if (campaignOpt.isEmpty()) {
+            return new CampaignValidationDTO(false, "Campaign not found.", null, null, null);
+        }
+
+        Campaign campaign = campaignOpt.get();
+        String message = validateCampaignState(campaign, true);
+        if (message != null) {
+            return new CampaignValidationDTO(false, message, campaign.getName(), campaign.getPrizeDescription(), campaign.getEndsAt());
+        }
+
+        return new CampaignValidationDTO(
+                true,
+                "Campaign is active.",
+                campaign.getName(),
+                campaign.getPrizeDescription(),
+                campaign.getEndsAt()
+        );
+    }
+
+    public Optional<CampaignEntry> tryCreateEntryForReview(User user, Review review) {
+        if (user.getCampaign() == null || user.isBanned() || !user.isVerifiedStudent()) {
+            return Optional.empty();
+        }
+
+        Campaign campaign = user.getCampaign();
+        if (!isWithinWindow(campaign, review.getCreatedAt())) {
+            return Optional.empty();
+        }
+
+        String validationMessage = validateCampaignState(campaign, false);
+        if (validationMessage != null) {
+            return Optional.empty();
+        }
+
+        if (review.getReviewText() == null || review.getReviewText().trim().length() < campaign.getMinReviewLength()) {
+            return Optional.empty();
+        }
+
+        if (campaignEntryRepo.existsByReview_Id(review.getId())) {
+            return Optional.empty();
+        }
+
+        long existingEntries = campaignEntryRepo.countByCampaign_IdAndUser_Id(campaign.getId(), user.getId());
+        if (existingEntries >= campaign.getMaxEntriesPerUser()) {
+            return Optional.empty();
+        }
+
+        CampaignEntry entry = new CampaignEntry();
+        entry.setCampaign(campaign);
+        entry.setUser(user);
+        entry.setReview(review);
+        entry.setEntryToken(generateUniqueEntryToken());
+
+        CampaignEntry saved = campaignEntryRepo.save(entry);
+        log.info("Campaign entry {} created for user {} on review {}", saved.getEntryToken(), user.getId(), review.getId());
+        return Optional.of(saved);
+    }
+
+    public List<CampaignEntrySummaryDTO> getEntriesForUser(User user) {
+        return campaignEntryRepo.findByUser_IdOrderByCreatedAtDesc(user.getId()).stream()
+                .map(entry -> new CampaignEntrySummaryDTO(
+                        entry.getEntryToken(),
+                        entry.getCampaign().getName(),
+                        entry.getReview().getUnit().getCode(),
+                        entry.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    public List<CampaignAdminDTO> listCampaigns() {
+        return campaignRepo.findAllByOrderByCreatedAtDesc().stream()
+                .map(this::toAdminDTO)
+                .toList();
+    }
+
+    public CampaignAdminDTO createCampaign(
+            String slug,
+            String code,
+            String name,
+            String prizeDescription,
+            Instant startsAt,
+            Instant endsAt,
+            Integer maxRedemptions,
+            int minReviewLength,
+            int maxEntriesPerUser
+    ) {
+        String normalizedSlug = requireNormalized(slug, "Campaign slug");
+        String normalizedCode = requireNormalized(code, "Promo code").toUpperCase();
+
+        if (campaignRepo.findBySlugIgnoreCase(normalizedSlug).isPresent()) {
+            throw new IllegalArgumentException("A campaign with that slug already exists.");
+        }
+        if (campaignRepo.findByCodeIgnoreCase(normalizedCode).isPresent()) {
+            throw new IllegalArgumentException("A campaign with that promo code already exists.");
+        }
+        if (!endsAt.isAfter(startsAt)) {
+            throw new IllegalArgumentException("Campaign end date must be after the start date.");
+        }
+
+        if (minReviewLength <= 0) {
+            minReviewLength = 50;
+        }
+        if (maxEntriesPerUser <= 0) {
+            maxEntriesPerUser = 5;
+        }
+
+        Campaign campaign = new Campaign();
+        campaign.setSlug(normalizedSlug);
+        campaign.setCode(normalizedCode);
+        campaign.setName(name.trim());
+        campaign.setPrizeDescription(prizeDescription != null ? prizeDescription.trim() : null);
+        campaign.setStartsAt(startsAt);
+        campaign.setEndsAt(endsAt);
+        campaign.setMaxRedemptions(maxRedemptions);
+        campaign.setMinReviewLength(minReviewLength);
+        campaign.setMaxEntriesPerUser(maxEntriesPerUser);
+        campaign.setActive(true);
+
+        return toAdminDTO(campaignRepo.save(campaign));
+    }
+
+    public CampaignAdminDTO setCampaignActive(String campaignId, boolean active) {
+        Campaign campaign = campaignRepo.findById(campaignId)
+                .orElseThrow(() -> new IllegalArgumentException("Campaign not found."));
+        campaign.setActive(active);
+        return toAdminDTO(campaignRepo.save(campaign));
+    }
+
+    public List<CampaignEntryAdminDTO> listEntriesForCampaign(String campaignId) {
+        if (!campaignRepo.existsById(campaignId)) {
+            throw new IllegalArgumentException("Campaign not found.");
+        }
+
+        return campaignEntryRepo.findByCampaign_IdOrderByCreatedAtDesc(campaignId).stream()
+                .map(entry -> new CampaignEntryAdminDTO(
+                        entry.getId(),
+                        entry.getEntryToken(),
+                        entry.getUser().getEmail(),
+                        entry.getReview().getUnit().getCode(),
+                        entry.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    private CampaignAdminDTO toAdminDTO(Campaign campaign) {
+        return new CampaignAdminDTO(
+                campaign.getId(),
+                campaign.getSlug(),
+                campaign.getCode(),
+                campaign.getName(),
+                campaign.getPrizeDescription(),
+                campaign.getStartsAt(),
+                campaign.getEndsAt(),
+                campaign.isActive(),
+                campaign.getMaxRedemptions(),
+                campaign.getMinReviewLength(),
+                campaign.getMaxEntriesPerUser(),
+                userRepo.countByCampaign_Id(campaign.getId()),
+                campaignEntryRepo.countByCampaign_Id(campaign.getId()),
+                campaign.getCreatedAt()
+        );
+    }
+
+    private String validateCampaignState(Campaign campaign, boolean checkRedemptions) {
+        if (!campaign.isActive()) {
+            return "This campaign is no longer active.";
+        }
+        Instant now = Instant.now();
+        if (now.isBefore(campaign.getStartsAt())) {
+            return "This campaign has not started yet.";
+        }
+        if (now.isAfter(campaign.getEndsAt())) {
+            return "This campaign has ended.";
+        }
+        if (checkRedemptions && campaign.getMaxRedemptions() != null) {
+            long currentSignups = userRepo.countByCampaign_Id(campaign.getId());
+            if (currentSignups >= campaign.getMaxRedemptions()) {
+                return "This campaign has reached its signup limit.";
+            }
+        }
+        return null;
+    }
+
+    private boolean isWithinWindow(Campaign campaign, Instant timestamp) {
+        return !timestamp.isBefore(campaign.getStartsAt()) && !timestamp.isAfter(campaign.getEndsAt());
+    }
+
+    private String generateUniqueEntryToken() {
+        for (int attempt = 0; attempt < 10; attempt++) {
+            String token = "CH-" + randomTokenSuffix();
+            if (campaignEntryRepo.findByEntryTokenIgnoreCase(token).isEmpty()) {
+                return token;
+            }
+        }
+        throw new IllegalStateException("Unable to generate a unique campaign entry token.");
+    }
+
+    private String randomTokenSuffix() {
+        StringBuilder builder = new StringBuilder(TOKEN_SUFFIX_LENGTH);
+        for (int i = 0; i < TOKEN_SUFFIX_LENGTH; i++) {
+            builder.append(TOKEN_CHARS.charAt(secureRandom.nextInt(TOKEN_CHARS.length())));
+        }
+        return builder.toString();
+    }
+
+    private Optional<String> normalize(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? Optional.empty() : Optional.of(trimmed);
+    }
+
+    private String requireNormalized(String value, String label) {
+        return normalize(value).orElseThrow(() -> new IllegalArgumentException(label + " is required."));
+    }
+}

--- a/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
@@ -4,6 +4,7 @@ import com.curtinhonestly.backend.domain.CampaignEntry;
 import com.curtinhonestly.backend.domain.Review;
 import com.curtinhonestly.backend.domain.Unit;
 import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.dto.CampaignProgressDTO;
 import com.curtinhonestly.backend.dto.ReviewCreateRequest;
 import com.curtinhonestly.backend.repo.ReviewRepo;
 import com.curtinhonestly.backend.repo.UnitRepo;
@@ -65,6 +66,10 @@ public class ReviewService {
         Unit unit = unitRepo.findByCode(request.unitCode())
                 .orElseThrow(() -> new RuntimeException("Unit not found with code: " + request.unitCode()));
 
+        if (reviewRepo.existsByUser_IdAndUnit_Id(user.getId(), unit.getId())) {
+            throw new IllegalArgumentException("You've already reviewed this unit. Delete your existing review from My Reviews before posting a new one.");
+        }
+
         // Build the Review server-side from only the user-settable fields.
         // createdAt and id are never taken from client input.
         Review review = new Review();
@@ -89,11 +94,15 @@ public class ReviewService {
 
     public ReviewCreationResult createReviewWithCampaignEntry(ReviewCreateRequest request) {
         Review savedReview = createReview(request);
-        Optional<CampaignEntry> entry = campaignService.tryCreateEntryForReview(savedReview.getUser(), savedReview);
-        return new ReviewCreationResult(savedReview, entry);
+        CampaignService.CampaignAwardResult award = campaignService.tryAwardCampaignEntries(savedReview.getUser(), savedReview);
+        return new ReviewCreationResult(savedReview, award.newEntry(), award.progress());
     }
 
-    public record ReviewCreationResult(Review review, Optional<CampaignEntry> campaignEntry) {}
+    public record ReviewCreationResult(
+            Review review,
+            Optional<CampaignEntry> campaignEntry,
+            CampaignProgressDTO campaignProgress
+    ) {}
 
     public void deleteReview(Review review) {
         String unitId = review.getUnit().getId();

--- a/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.curtinhonestly.backend.service;
 
+import com.curtinhonestly.backend.domain.CampaignEntry;
 import com.curtinhonestly.backend.domain.Review;
 import com.curtinhonestly.backend.domain.Unit;
 import com.curtinhonestly.backend.domain.User;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Slf4j
@@ -31,6 +33,7 @@ public class ReviewService {
     private final UnitRepo unitRepo;
     private final ProfanityFilterService profanityFilterService;
     private final UnitAggregateService unitAggregateService;
+    private final CampaignService campaignService;
 
     public List<Review> getReviewsByUnitCode(String unitCode) {
         Unit unit = unitService.getUnitByCode(unitCode);
@@ -83,6 +86,14 @@ public class ReviewService {
         unitAggregateService.recalculateForUnit(unit.getId());
         return saved;
     }
+
+    public ReviewCreationResult createReviewWithCampaignEntry(ReviewCreateRequest request) {
+        Review savedReview = createReview(request);
+        Optional<CampaignEntry> entry = campaignService.tryCreateEntryForReview(savedReview.getUser(), savedReview);
+        return new ReviewCreationResult(savedReview, entry);
+    }
+
+    public record ReviewCreationResult(Review review, Optional<CampaignEntry> campaignEntry) {}
 
     public void deleteReview(Review review) {
         String unitId = review.getUnit().getId();

--- a/backend/src/main/java/com/curtinhonestly/backend/service/UserService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/UserService.java
@@ -1,5 +1,6 @@
 package com.curtinhonestly.backend.service;
 
+import com.curtinhonestly.backend.domain.Campaign;
 import com.curtinhonestly.backend.domain.User;
 import com.curtinhonestly.backend.domain.UserRole;
 import com.curtinhonestly.backend.repo.UserRepo;
@@ -22,6 +23,10 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public User createUser(String email, String password) {
+        return createUser(email, password, null, null);
+    }
+
+    public User createUser(String email, String password, Campaign campaign, String ref) {
         String normalizedEmail = EmailNormalizer.normalize(email);
         log.info("Creating user: {}", normalizedEmail);
 
@@ -35,8 +40,15 @@ public class UserService {
         user.setVerifiedStudent(StudentEmailValidator.isStudentEmail(normalizedEmail));
         user.setRoles(List.of(UserRole.ROLE_USER));
 
+        if (campaign != null) {
+            user.setCampaign(campaign);
+            user.setRegisteredViaRef(ref != null && !ref.isBlank() ? ref.trim() : campaign.getSlug());
+        }
+
         User savedUser = userRepo.saveAndFlush(user);
-        log.info("User created successfully with ID: {}, verifiedStudent={}", savedUser.getId(), savedUser.isVerifiedStudent());
+        log.info("User created successfully with ID: {}, verifiedStudent={}, campaign={}",
+                savedUser.getId(), savedUser.isVerifiedStudent(),
+                campaign != null ? campaign.getSlug() : "none");
         return savedUser;
     }
 

--- a/backend/src/test/java/com/curtinhonestly/backend/resource/CampaignRedemptionLockTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/resource/CampaignRedemptionLockTest.java
@@ -1,0 +1,109 @@
+package com.curtinhonestly.backend.resource;
+
+import com.curtinhonestly.backend.config.TestcontainersConfig;
+import com.curtinhonestly.backend.domain.Campaign;
+import com.curtinhonestly.backend.repo.CampaignRepo;
+import com.curtinhonestly.backend.repo.UserRepo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Proves the fix-plan #4 lock actually spans the whole redemption: two
+// concurrent registrations against a campaign with exactly one slot left
+// must not both succeed.
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfig.class)
+class CampaignRedemptionLockTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CampaignRepo campaignRepo;
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @Test
+    void concurrentRegistrationsCannotExceedMaxRedemptions() throws Exception {
+        Campaign campaign = new Campaign();
+        campaign.setSlug("lock-test-" + UUID.randomUUID());
+        campaign.setCode("LOCK" + System.currentTimeMillis());
+        campaign.setName("Redemption Lock Test Campaign");
+        campaign.setStartsAt(Instant.now().minusSeconds(60));
+        campaign.setEndsAt(Instant.now().plusSeconds(3600));
+        campaign.setMaxRedemptions(1);
+        campaign.setMinReviewLength(10);
+        campaign.setMaxEntriesPerUser(1);
+        campaign.setRequireVerifiedStudent(false);
+        campaign.setRequiredReviewCount(1);
+        campaign.setActive(true);
+        campaign = campaignRepo.save(campaign);
+        String code = campaign.getCode();
+
+        String emailA = "lock-a-" + UUID.randomUUID() + "@example.com";
+        String emailB = "lock-b-" + UUID.randomUUID() + "@example.com";
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch go = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        Callable<Integer> registerA = registerCallable(emailA, code, ready, go);
+        Callable<Integer> registerB = registerCallable(emailB, code, ready, go);
+
+        Future<Integer> futureA = executor.submit(registerA);
+        Future<Integer> futureB = executor.submit(registerB);
+
+        ready.await(5, TimeUnit.SECONDS);
+        go.countDown();
+
+        int statusA = futureA.get(15, TimeUnit.SECONDS);
+        int statusB = futureB.get(15, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        long successCount = List.of(statusA, statusB).stream().filter(s -> s == 200).count();
+        assertThat(successCount).isEqualTo(1);
+        assertThat(userRepo.countByCampaign_Id(campaign.getId())).isEqualTo(1);
+    }
+
+    private Callable<Integer> registerCallable(String email, String code, CountDownLatch ready, CountDownLatch go) {
+        return () -> {
+            Map<String, Object> payload = Map.of(
+                    "email", email,
+                    "password", "password123",
+                    "promoCode", code
+            );
+            String body = objectMapper.writeValueAsString(payload);
+            ready.countDown();
+            go.await();
+            return mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andReturn()
+                    .getResponse()
+                    .getStatus();
+        };
+    }
+}

--- a/backend/src/test/java/com/curtinhonestly/backend/resource/CampaignValidateTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/resource/CampaignValidateTest.java
@@ -1,0 +1,90 @@
+package com.curtinhonestly.backend.resource;
+
+import com.curtinhonestly.backend.config.TestcontainersConfig;
+import com.curtinhonestly.backend.domain.Campaign;
+import com.curtinhonestly.backend.repo.CampaignRepo;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfig.class)
+class CampaignValidateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CampaignRepo campaignRepo;
+
+    @Test
+    void notFoundExpiredAndFullReturnTheSameBody() throws Exception {
+        Campaign expired = new Campaign();
+        expired.setSlug("expired-" + UUID.randomUUID());
+        expired.setCode("EXP" + System.currentTimeMillis());
+        expired.setName("Expired Campaign");
+        expired.setStartsAt(Instant.now().minusSeconds(7200));
+        expired.setEndsAt(Instant.now().minusSeconds(3600));
+        expired.setActive(true);
+        expired = campaignRepo.save(expired);
+
+        Campaign full = new Campaign();
+        full.setSlug("full-" + UUID.randomUUID());
+        full.setCode("FULL" + System.currentTimeMillis());
+        full.setName("Full Campaign");
+        full.setStartsAt(Instant.now().minusSeconds(60));
+        full.setEndsAt(Instant.now().plusSeconds(3600));
+        full.setMaxRedemptions(0); // zero slots -> always reads as full
+        full.setActive(true);
+        full = campaignRepo.save(full);
+
+        MvcResult notFoundResult = mockMvc.perform(get("/campaigns/validate").param("code", "DOES-NOT-EXIST"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(false))
+                .andReturn();
+
+        MvcResult expiredResult = mockMvc.perform(get("/campaigns/validate").param("code", expired.getCode()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(false))
+                .andReturn();
+
+        MvcResult fullResult = mockMvc.perform(get("/campaigns/validate").param("code", full.getCode()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(false))
+                .andReturn();
+
+        String notFoundBody = notFoundResult.getResponse().getContentAsString();
+        String expiredBody = expiredResult.getResponse().getContentAsString();
+        String fullBody = fullResult.getResponse().getContentAsString();
+
+        // Same message and no campaign details leaked for any invalid reason -
+        // an attacker probing codes can't tell not-found from expired from full.
+        assertThat(expiredBody).isEqualTo(notFoundBody);
+        assertThat(fullBody).isEqualTo(notFoundBody);
+    }
+
+    @Test
+    void exceedingTheRateLimitReturns429() throws Exception {
+        int lastStatus = 0;
+        for (int i = 0; i < 11; i++) {
+            lastStatus = mockMvc.perform(get("/campaigns/validate").param("code", "RATE-LIMIT-PROBE-" + i))
+                    .andReturn()
+                    .getResponse()
+                    .getStatus();
+        }
+        assertThat(lastStatus).isEqualTo(429);
+    }
+}

--- a/backend/src/test/java/com/curtinhonestly/backend/resource/ReviewCampaignAggregateTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/resource/ReviewCampaignAggregateTest.java
@@ -1,0 +1,117 @@
+package com.curtinhonestly.backend.resource;
+
+import com.curtinhonestly.backend.config.TestcontainersConfig;
+import com.curtinhonestly.backend.domain.Campaign;
+import com.curtinhonestly.backend.domain.Faculty;
+import com.curtinhonestly.backend.domain.Unit;
+import com.curtinhonestly.backend.domain.UnitLevel;
+import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.domain.UserRole;
+import com.curtinhonestly.backend.repo.CampaignRepo;
+import com.curtinhonestly.backend.repo.UnitRepo;
+import com.curtinhonestly.backend.repo.UserRepo;
+import com.curtinhonestly.backend.security.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Confirms that wiring the campaign entry-awarding hook onto the
+// ReviewCreateRequest DTO path (reconciled with dev's DTO-based POST /reviews)
+// did not drop the perf-work aggregate recalculation dev added separately.
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfig.class)
+class ReviewCampaignAggregateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UnitRepo unitRepo;
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @Autowired
+    private CampaignRepo campaignRepo;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Test
+    void submittingAReviewWithCampaignAttributionStillRecalculatesUnitAggregates() throws Exception {
+        Unit unit = new Unit();
+        unit.setCode("AGGTEST" + System.currentTimeMillis());
+        unit.setName("Aggregate Test Unit");
+        unit.setDescription("Unit used to prove aggregates still recalculate under the campaign path.");
+        unit.setFaculty(Faculty.SCIENCE_AND_ENGINEERING);
+        unit.setLevel(UnitLevel.UNDERGRADUATE);
+        unit = unitRepo.save(unit);
+        assertThat(unit.getReviewCount()).isZero();
+
+        Campaign campaign = new Campaign();
+        campaign.setSlug("agg-test-" + UUID.randomUUID());
+        campaign.setCode("AGGTEST" + System.currentTimeMillis());
+        campaign.setName("Aggregate Test Campaign");
+        campaign.setStartsAt(Instant.now().minusSeconds(60));
+        campaign.setEndsAt(Instant.now().plusSeconds(3600));
+        campaign.setMinReviewLength(10);
+        campaign.setMaxEntriesPerUser(5);
+        campaign.setRequireVerifiedStudent(false);
+        campaign.setRequiredReviewCount(1);
+        campaign.setActive(true);
+        campaign = campaignRepo.save(campaign);
+
+        User user = new User();
+        user.setEmail("agg-campaign-test@student.curtin.edu.au");
+        user.setPassword(passwordEncoder.encode("password123"));
+        user.setRoles(List.of(UserRole.ROLE_USER));
+        user.setCampaign(campaign);
+        user = userRepo.saveAndFlush(user);
+
+        String token = jwtUtil.generateToken(user.getEmail(), List.of("ROLE_USER"));
+
+        Map<String, Object> payload = Map.of(
+                "rating", 5,
+                "finalGrade", 90,
+                "reviewText", "This review is long enough to qualify for a campaign entry.",
+                "semesterTaken", "Semester 1, 2026",
+                "professor", "Prof Test",
+                "workload", 5,
+                "hasExam", true,
+                "wouldTakeAgain", true,
+                "unitCode", unit.getCode()
+        );
+
+        mockMvc.perform(post("/reviews")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isCreated());
+
+        Unit refreshed = unitRepo.findById(unit.getId()).orElseThrow();
+        assertThat(refreshed.getReviewCount()).isEqualTo(1);
+        assertThat(refreshed.getAverageRating()).isEqualTo(5.0);
+    }
+}

--- a/backend/src/test/java/com/curtinhonestly/backend/resource/ReviewCreateDtoTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/resource/ReviewCreateDtoTest.java
@@ -90,8 +90,11 @@ class ReviewCreateDtoTest {
                 .andExpect(status().isCreated())
                 .andReturn();
 
+        // POST /reviews now returns a CreateReviewResponseDTO envelope (review +
+        // campaign entry fields) rather than the bare ReviewDTO, since the campaign
+        // work wraps review creation to award entries in the same call.
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
-        Instant returnedCreatedAt = Instant.parse(body.get("createdAt").asText());
+        Instant returnedCreatedAt = Instant.parse(body.get("review").get("createdAt").asText());
 
         assertThat(returnedCreatedAt).isCloseTo(Instant.now(), org.assertj.core.api.Assertions.within(1, ChronoUnit.MINUTES));
         assertThat(result.getResponse().getHeader("Location")).doesNotContain("client-supplied-id-should-be-ignored");

--- a/backend/src/test/java/com/curtinhonestly/backend/service/CampaignReEarnTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/service/CampaignReEarnTest.java
@@ -1,0 +1,99 @@
+package com.curtinhonestly.backend.service;
+
+import com.curtinhonestly.backend.config.TestcontainersConfig;
+import com.curtinhonestly.backend.domain.Campaign;
+import com.curtinhonestly.backend.domain.Faculty;
+import com.curtinhonestly.backend.domain.Unit;
+import com.curtinhonestly.backend.domain.UnitLevel;
+import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.domain.UserRole;
+import com.curtinhonestly.backend.dto.ReviewCreateRequest;
+import com.curtinhonestly.backend.repo.CampaignEntryRepo;
+import com.curtinhonestly.backend.repo.CampaignRepo;
+import com.curtinhonestly.backend.repo.UnitRepo;
+import com.curtinhonestly.backend.repo.UserRepo;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Import(TestcontainersConfig.class)
+class CampaignReEarnTest {
+
+    @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
+    private CampaignRepo campaignRepo;
+
+    @Autowired
+    private CampaignEntryRepo campaignEntryRepo;
+
+    @Autowired
+    private UnitRepo unitRepo;
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @WithMockUser(username = "re-earn-test@student.curtin.edu.au")
+    void deletingAndResubmittingAReviewDoesNotEarnASecondEntry() {
+        Unit unit = new Unit();
+        unit.setCode("REEARN" + System.currentTimeMillis());
+        unit.setName("Re-earn Test Unit");
+        unit.setDescription("Unit used to prove the delete-and-resubmit loop is closed.");
+        unit.setFaculty(Faculty.SCIENCE_AND_ENGINEERING);
+        unit.setLevel(UnitLevel.UNDERGRADUATE);
+        unit = unitRepo.save(unit);
+
+        Campaign campaign = new Campaign();
+        campaign.setSlug("re-earn-" + UUID.randomUUID());
+        campaign.setCode("REEARN" + System.currentTimeMillis());
+        campaign.setName("Re-earn Test Campaign");
+        campaign.setStartsAt(Instant.now().minusSeconds(60));
+        campaign.setEndsAt(Instant.now().plusSeconds(3600));
+        campaign.setMinReviewLength(10);
+        campaign.setMaxEntriesPerUser(5);
+        campaign.setRequireVerifiedStudent(false);
+        campaign.setRequiredReviewCount(1);
+        campaign.setActive(true);
+        campaign = campaignRepo.save(campaign);
+
+        User user = new User();
+        user.setEmail("re-earn-test@student.curtin.edu.au");
+        user.setPassword(passwordEncoder.encode("password123"));
+        user.setRoles(List.of(UserRole.ROLE_USER));
+        user.setCampaign(campaign);
+        user = userRepo.saveAndFlush(user);
+
+        ReviewCreateRequest request = new ReviewCreateRequest(
+                4, 80, "This review is long enough to qualify for the campaign entry.",
+                "Semester 1, 2026", "Prof Test", 5, true, true, unit.getCode());
+
+        // First submission earns an entry.
+        var firstResult = reviewService.createReviewWithCampaignEntry(request);
+        assertThat(firstResult.campaignEntry()).isPresent();
+        assertThat(campaignEntryRepo.countByCampaign_IdAndUser_Id(campaign.getId(), user.getId())).isEqualTo(1);
+
+        // Delete the review - the entry (and its token) must survive.
+        reviewService.deleteReviewById(firstResult.review().getId());
+        assertThat(campaignEntryRepo.countByCampaign_IdAndUser_Id(campaign.getId(), user.getId())).isEqualTo(1);
+
+        // Resubmitting a fresh qualifying review for the SAME unit must not earn a second entry.
+        var secondResult = reviewService.createReviewWithCampaignEntry(request);
+        assertThat(secondResult.campaignEntry()).isEmpty();
+        assertThat(campaignEntryRepo.countByCampaign_IdAndUser_Id(campaign.getId(), user.getId())).isEqualTo(1);
+    }
+}

--- a/frontend/src/app/components/account/account.component.css
+++ b/frontend/src/app/components/account/account.component.css
@@ -118,6 +118,12 @@
   line-height: 1.5;
 }
 
+.campaign-progress {
+  margin: 12px 0 0;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
 .entries-heading {
   margin: 16px 0 8px;
   font-size: 1rem;

--- a/frontend/src/app/components/account/account.component.css
+++ b/frontend/src/app/components/account/account.component.css
@@ -108,6 +108,51 @@
   font-size: 0.9rem;
 }
 
+.campaign-section {
+  border-color: #bfdbfe;
+}
+
+.campaign-note {
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.entries-heading {
+  margin: 16px 0 8px;
+  font-size: 1rem;
+}
+
+.entry-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.entry-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.entry-list li:last-child {
+  border-bottom: none;
+}
+
+.entry-token {
+  font-family: monospace;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #1d4ed8;
+}
+
+.entry-meta {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
 .page-footer {
   margin-top: 8px;
   font-size: 0.9rem;

--- a/frontend/src/app/components/account/account.component.html
+++ b/frontend/src/app/components/account/account.component.html
@@ -27,6 +27,39 @@
     </dl>
   </section>
 
+  @if (account()?.campaignName) {
+    <section class="account-section card campaign-section">
+      <h2>Campaign</h2>
+      <p class="section-hint">
+        You joined via <strong>{{ account()?.campaignName }}</strong>.
+        @if (account()?.campaignPrizeDescription) {
+          Prize: {{ account()?.campaignPrizeDescription }}.
+        }
+        @if (account()?.campaignEndsAt) {
+          Draw entries close {{ account()?.campaignEndsAt | date: 'mediumDate' }}.
+        }
+      </p>
+
+      @if (!authService.verifiedStudent()) {
+        <p class="campaign-note">Verify your student email below to earn draw entries when you leave qualifying reviews.</p>
+      }
+
+      @if (account()?.campaignEntries?.length) {
+        <h3 class="entries-heading">Your draw entries</h3>
+        <ul class="entry-list">
+          @for (entry of account()?.campaignEntries; track entry.entryToken) {
+            <li>
+              <span class="entry-token">{{ entry.entryToken }}</span>
+              <span class="entry-meta">{{ entry.unitCode }} · {{ entry.createdAt | date: 'medium' }}</span>
+            </li>
+          }
+        </ul>
+      } @else if (authService.verifiedStudent()) {
+        <p class="campaign-note">Leave a qualifying review on any unit to receive an entry token.</p>
+      }
+    </section>
+  }
+
   <section class="account-section card">
     <h2>Update email</h2>
     <p class="section-hint">Change the email you use to sign in. You will need your current password.</p>

--- a/frontend/src/app/components/account/account.component.html
+++ b/frontend/src/app/components/account/account.component.html
@@ -40,8 +40,14 @@
         }
       </p>
 
-      @if (!authService.verifiedStudent()) {
+      @if (account()?.campaignProgress?.requireVerifiedStudent && !authService.verifiedStudent()) {
         <p class="campaign-note">Verify your student email below to earn draw entries when you leave qualifying reviews.</p>
+      } @else if (account()?.campaignProgress && !account()?.campaignProgress?.requireVerifiedStudent) {
+        <p class="campaign-note">This campaign accepts unverified accounts (e.g. alumni). One review per unit counts toward your entry.</p>
+      }
+
+      @if (campaignProgressLabel()) {
+        <p class="campaign-progress">{{ campaignProgressLabel() }}</p>
       }
 
       @if (account()?.campaignEntries?.length) {
@@ -54,8 +60,8 @@
             </li>
           }
         </ul>
-      } @else if (authService.verifiedStudent()) {
-        <p class="campaign-note">Leave a qualifying review on any unit to receive an entry token.</p>
+      } @else if (authService.verifiedStudent() || !account()?.campaignProgress?.requireVerifiedStudent) {
+        <p class="campaign-note">Leave qualifying reviews on different units to receive a draw entry token.</p>
       }
     </section>
   }

--- a/frontend/src/app/components/account/account.component.ts
+++ b/frontend/src/app/components/account/account.component.ts
@@ -43,6 +43,29 @@ export class AccountComponent implements OnInit {
     });
   }
 
+  campaignProgressLabel(): string | null {
+    const progress = this.account()?.campaignProgress;
+    if (!progress) {
+      return null;
+    }
+
+    if (progress.entriesEarned >= progress.maxEntries) {
+      return `You have ${progress.entriesEarned} draw ${progress.entriesEarned === 1 ? 'entry' : 'entries'}.`;
+    }
+
+    const remainder = progress.qualifyingReviews % progress.requiredReviews;
+    if (remainder === 0 && progress.qualifyingReviews === 0) {
+      return `Leave ${progress.requiredReviews} qualifying review${progress.requiredReviews === 1 ? '' : 's'} on different units to enter the draw.`;
+    }
+
+    if (remainder === 0) {
+      return `${progress.qualifyingReviews} qualifying reviews submitted.`;
+    }
+
+    const needed = progress.requiredReviews - remainder;
+    return `${progress.qualifyingReviews}/${progress.requiredReviews} qualifying reviews — ${needed} more needed for a draw entry.`;
+  }
+
   onUpdateEmail() {
     this.clearMessages();
     this.isLoading.set(true);

--- a/frontend/src/app/components/account/account.component.ts
+++ b/frontend/src/app/components/account/account.component.ts
@@ -1,14 +1,14 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { AuthService } from '../../services/auth.service';
+import { AuthService, AccountStatus } from '../../services/auth.service';
 import { SeoService } from '../../services/seo.service';
 
 @Component({
   selector: 'app-account',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, DatePipe],
   templateUrl: './account.component.html',
   styleUrl: './account.component.css'
 })
@@ -16,6 +16,8 @@ export class AccountComponent implements OnInit {
   protected authService = inject(AuthService);
   private router = inject(Router);
   private seoService = inject(SeoService);
+
+  account = signal<AccountStatus | null>(null);
 
   newEmail = '';
   emailPassword = '';
@@ -36,6 +38,7 @@ export class AccountComponent implements OnInit {
     }
 
     this.authService.refreshAccountStatus().subscribe({
+      next: (status) => this.account.set(status),
       error: () => this.authService.logout()
     });
   }
@@ -53,6 +56,7 @@ export class AccountComponent implements OnInit {
         this.successMessage.set('Email updated successfully.');
         this.newEmail = '';
         this.emailPassword = '';
+        this.refreshAccount();
       },
       error: (err) => {
         this.isLoading.set(false);
@@ -79,6 +83,7 @@ export class AccountComponent implements OnInit {
         this.successMessage.set('Your account is now verified as a Curtin student.');
         this.studentEmail = '';
         this.verifyPassword = '';
+        this.refreshAccount();
       },
       error: (err) => {
         this.isLoading.set(false);
@@ -105,6 +110,12 @@ export class AccountComponent implements OnInit {
         this.isLoading.set(false);
         this.errorMessage.set(err.error?.error || 'Failed to delete account.');
       }
+    });
+  }
+
+  private refreshAccount() {
+    this.authService.refreshAccountStatus().subscribe({
+      next: (status) => this.account.set(status)
     });
   }
 

--- a/frontend/src/app/components/add-review/add-review.component.css
+++ b/frontend/src/app/components/add-review/add-review.component.css
@@ -128,6 +128,16 @@
   border: 1px solid #feb2b2;
 }
 
+.success-box {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  padding: 12px;
+  border-radius: var(--radius-none);
+  margin-bottom: 15px;
+  border: 1px solid #bfdbfe;
+  line-height: 1.5;
+}
+
 .btn-secondary {
   background-color: var(--surface-muted);
   color: var(--text-primary);

--- a/frontend/src/app/components/add-review/add-review.component.html
+++ b/frontend/src/app/components/add-review/add-review.component.html
@@ -66,6 +66,10 @@
       {{ errorMessage() }}
     </div>
 
+    @if (successMessage()) {
+      <div class="success-box">{{ successMessage() }}</div>
+    }
+
     <div class="form-actions">
       <button type="button" (click)="onCancel()" class="btn btn-secondary" [disabled]="isLoading()">Cancel</button>
       <button type="submit" class="btn btn-primary" [disabled]="isLoading() || !reviewText() || reviewText().length < 10">

--- a/frontend/src/app/components/add-review/add-review.component.ts
+++ b/frontend/src/app/components/add-review/add-review.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ReviewService, CreateReviewResponse } from '../../services/review.service';
+import { CampaignProgress, CreateReviewResponse, ReviewService } from '../../services/review.service';
 import { BANNED_WORDS } from '../../models/profanity-list';
 
 @Component({
@@ -33,7 +33,7 @@ export class AddReviewComponent {
   successMessage = signal<string | null>(null);
 
   private readonly profanityRegex = new RegExp(
-    `\\b(${BANNED_WORDS.map(word => this.escapeRegExp(word)).join('|')})\\b`, 
+    `\\b(${BANNED_WORDS.map(word => this.escapeRegExp(word)).join('|')})\\b`,
     'i'
   );
 
@@ -81,19 +81,7 @@ export class AddReviewComponent {
     this.reviewService.createReview(reviewData).subscribe({
       next: (response: CreateReviewResponse) => {
         this.isLoading.set(false);
-
-        if (response.campaignEntryToken) {
-          this.successMessage.set(
-            `Review submitted! You're entered in the ${response.campaignName ?? 'campaign'} draw. Entry token: ${response.campaignEntryToken}`
-          );
-          setTimeout(() => {
-            this.reviewAdded.emit();
-            this.resetForm();
-          }, 4000);
-        } else {
-          this.reviewAdded.emit();
-          this.resetForm();
-        }
+        this.handleSuccess(response);
       },
       error: (err) => {
         this.isLoading.set(false);
@@ -102,6 +90,55 @@ export class AddReviewComponent {
         this.reviewError.emit(message);
       }
     });
+  }
+
+  private handleSuccess(response: CreateReviewResponse) {
+    const progressMessage = this.buildProgressMessage(response.campaignProgress);
+
+    if (response.campaignEntryToken) {
+      this.successMessage.set(
+        `Review submitted! You're entered in the ${response.campaignName ?? 'campaign'} draw. Entry token: ${response.campaignEntryToken}`
+      );
+      setTimeout(() => {
+        this.reviewAdded.emit();
+        this.resetForm();
+      }, 4000);
+      return;
+    }
+
+    if (progressMessage) {
+      this.successMessage.set(`Review submitted! ${progressMessage}`);
+      setTimeout(() => {
+        this.reviewAdded.emit();
+        this.resetForm();
+      }, 3000);
+      return;
+    }
+
+    this.reviewAdded.emit();
+    this.resetForm();
+  }
+
+  private buildProgressMessage(progress: CampaignProgress | null): string | null {
+    if (!progress) {
+      return null;
+    }
+
+    if (progress.requireVerifiedStudent && progress.entriesEarned === 0 && progress.qualifyingReviews > 0) {
+      return 'Verify your student email to earn draw entries.';
+    }
+
+    if (progress.entriesEarned >= progress.maxEntries) {
+      return 'You have earned the maximum draw entries for this campaign.';
+    }
+
+    const remainder = progress.qualifyingReviews % progress.requiredReviews;
+    if (remainder !== 0) {
+      const needed = progress.requiredReviews - remainder;
+      return `${needed} more qualifying review${needed === 1 ? '' : 's'} needed for a draw entry (${progress.qualifyingReviews}/${progress.requiredReviews}).`;
+    }
+
+    return null;
   }
 
   resetForm() {

--- a/frontend/src/app/components/add-review/add-review.component.ts
+++ b/frontend/src/app/components/add-review/add-review.component.ts
@@ -1,8 +1,7 @@
 import { Component, inject, input, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ReviewService } from '../../services/review.service';
-import { Router } from '@angular/router';
+import { ReviewService, CreateReviewResponse } from '../../services/review.service';
 import { BANNED_WORDS } from '../../models/profanity-list';
 
 @Component({
@@ -14,13 +13,12 @@ import { BANNED_WORDS } from '../../models/profanity-list';
 })
 export class AddReviewComponent {
   private reviewService = inject(ReviewService);
-  private router = inject(Router);
 
   unitCode = input.required<string>();
   reviewAdded = output<void>();
+  reviewError = output<string>();
   cancel = output<void>();
 
-  // Form fields
   rating = signal(5);
   reviewText = signal('');
   semesterTaken = signal('Semester 1, 2026');
@@ -32,15 +30,15 @@ export class AddReviewComponent {
 
   isLoading = signal(false);
   errorMessage = signal<string | null>(null);
+  successMessage = signal<string | null>(null);
 
-  // Pre-compile the profanity regex once
   private readonly profanityRegex = new RegExp(
     `\\b(${BANNED_WORDS.map(word => this.escapeRegExp(word)).join('|')})\\b`, 
     'i'
   );
 
   private escapeRegExp(string: string) {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
   private containsProfanity(text: string): boolean {
@@ -54,13 +52,11 @@ export class AddReviewComponent {
       return;
     }
 
-    // Validate Grade
     if (this.finalGrade() !== null && (this.finalGrade()! < 0 || this.finalGrade()! > 100)) {
       this.errorMessage.set('Final grade must be between 0 and 100%.');
       return;
     }
 
-    // Profanity Check
     if (this.containsProfanity(this.reviewText())) {
       this.errorMessage.set('Your review contains language that violates our community standards. Please keep it professional.');
       return;
@@ -68,6 +64,7 @@ export class AddReviewComponent {
 
     this.isLoading.set(true);
     this.errorMessage.set(null);
+    this.successMessage.set(null);
 
     const reviewData = {
       rating: this.rating(),
@@ -78,19 +75,31 @@ export class AddReviewComponent {
       hasExam: this.hasExam(),
       wouldTakeAgain: this.wouldTakeAgain(),
       finalGrade: this.finalGrade(),
-      unit: { code: this.unitCode() }
+      unitCode: this.unitCode()
     };
 
     this.reviewService.createReview(reviewData).subscribe({
-      next: () => {
+      next: (response: CreateReviewResponse) => {
         this.isLoading.set(false);
-        this.reviewAdded.emit();
-        // Reset form
-        this.resetForm();
+
+        if (response.campaignEntryToken) {
+          this.successMessage.set(
+            `Review submitted! You're entered in the ${response.campaignName ?? 'campaign'} draw. Entry token: ${response.campaignEntryToken}`
+          );
+          setTimeout(() => {
+            this.reviewAdded.emit();
+            this.resetForm();
+          }, 4000);
+        } else {
+          this.reviewAdded.emit();
+          this.resetForm();
+        }
       },
       error: (err) => {
         this.isLoading.set(false);
-        this.errorMessage.set(err.error?.error || 'Failed to submit review. Please try again.');
+        const message = err.error?.error || 'Failed to submit review. Please try again.';
+        this.errorMessage.set(message);
+        this.reviewError.emit(message);
       }
     });
   }
@@ -104,6 +113,7 @@ export class AddReviewComponent {
     this.hasExam.set(false);
     this.wouldTakeAgain.set(true);
     this.finalGrade.set(null);
+    this.successMessage.set(null);
   }
 
   onCancel() {

--- a/frontend/src/app/components/my-reviews/my-reviews.component.ts
+++ b/frontend/src/app/components/my-reviews/my-reviews.component.ts
@@ -45,7 +45,7 @@ export class MyReviewsComponent implements OnInit {
       switchMap(query =>
         this.unitService.getUnits(0, 20, query || undefined, [], undefined, 'code')
       ),
-      map(page => page.content)
+      map(page => page.content.filter(unit => !this.hasReviewForUnit(unit.code)))
     );
   }
 
@@ -84,8 +84,13 @@ export class MyReviewsComponent implements OnInit {
   }
 
   selectUnit(unit: UnitSummary) {
+    if (this.hasReviewForUnit(unit.code)) {
+      this.errorMessage.set('You have already reviewed this unit. Delete your existing review below if you want to post a new one.');
+      return;
+    }
     this.selectedUnitCode.set(unit.code);
     this.selectedUnitName.set(unit.name);
+    this.errorMessage.set(null);
   }
 
   onReviewAdded() {
@@ -110,5 +115,9 @@ export class MyReviewsComponent implements OnInit {
 
   viewUnit(code: string) {
     this.router.navigate(['/units', code]);
+  }
+
+  private hasReviewForUnit(unitCode: string): boolean {
+    return this.reviews().some(review => review.unitCode === unitCode);
   }
 }

--- a/frontend/src/app/components/register/register.component.css
+++ b/frontend/src/app/components/register/register.component.css
@@ -63,6 +63,21 @@ input:focus {
   margin-top: 5px;
 }
 
+.optional {
+  font-weight: 400;
+  color: var(--text-secondary);
+}
+
+.campaign-banner {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+  padding: 12px;
+  border-left: 4px solid #2563eb;
+  margin-bottom: 20px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
 .btn-primary {
   width: 100%;
   background-color: var(--primary-color);

--- a/frontend/src/app/components/register/register.component.html
+++ b/frontend/src/app/components/register/register.component.html
@@ -19,6 +19,24 @@
       </div>
 
       <div class="form-group">
+        <label for="promoCode">Promo code <span class="optional">(optional)</span></label>
+        <input
+          type="text"
+          id="promoCode"
+          name="promoCode"
+          [(ngModel)]="promoCode"
+          (ngModelChange)="onPromoCodeChange()"
+          placeholder="e.g. CURTIN-JUL26"
+          autocomplete="off"
+        >
+        <div class="hint">Enter a promo code from a Discord post or outreach campaign to join a prize draw.</div>
+      </div>
+
+      @if (campaignMessage()) {
+        <div class="campaign-banner">{{ campaignMessage() }}</div>
+      }
+
+      <div class="form-group">
         <label for="password">Password</label>
         <input 
           type="password" 

--- a/frontend/src/app/components/register/register.component.ts
+++ b/frontend/src/app/components/register/register.component.ts
@@ -1,9 +1,13 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 import { SeoService } from '../../services/seo.service';
+import { CampaignService } from '../../services/campaign.service';
+
+const CAMPAIGN_REF_KEY = 'campaign_ref';
+const CAMPAIGN_CODE_KEY = 'campaign_code';
 
 @Component({
   selector: 'app-register',
@@ -14,19 +18,45 @@ import { SeoService } from '../../services/seo.service';
 })
 export class RegisterComponent implements OnInit {
   private authService = inject(AuthService);
+  private campaignService = inject(CampaignService);
   private router = inject(Router);
   private seoService = inject(SeoService);
-
-  ngOnInit(): void {
-    this.seoService.noIndex('Register | CurtinHonestly');
-  }
+  private route = inject(ActivatedRoute);
 
   email = '';
   password = '';
   confirmPassword = '';
+  promoCode = '';
+  ref = '';
+  campaignMessage = signal<string | null>(null);
   errorMessage = signal<string | null>(null);
   successMessage = signal<string | null>(null);
   isLoading = signal(false);
+
+  ngOnInit() {
+    this.seoService.noIndex('Register | CurtinHonestly');
+
+    this.route.queryParamMap.subscribe(params => {
+      const refParam = params.get('ref') ?? localStorage.getItem(CAMPAIGN_REF_KEY) ?? '';
+      const codeParam = params.get('code') ?? localStorage.getItem(CAMPAIGN_CODE_KEY) ?? '';
+
+      if (params.get('ref')) {
+        localStorage.setItem(CAMPAIGN_REF_KEY, refParam);
+      }
+      if (params.get('code')) {
+        localStorage.setItem(CAMPAIGN_CODE_KEY, codeParam);
+      }
+
+      this.ref = refParam;
+      if (codeParam) {
+        this.promoCode = codeParam;
+      }
+
+      if (refParam || codeParam) {
+        this.validateCampaign(refParam, codeParam);
+      }
+    });
+  }
 
   onSubmit() {
     if (this.password !== this.confirmPassword) {
@@ -37,9 +67,17 @@ export class RegisterComponent implements OnInit {
     this.isLoading.set(true);
     this.errorMessage.set(null);
 
-    this.authService.register({ email: this.email, password: this.password }).subscribe({
+    this.authService.register({
+      email: this.email,
+      password: this.password,
+      ref: this.ref || undefined,
+      promoCode: this.promoCode || undefined
+    }).subscribe({
       next: (response) => {
         this.isLoading.set(false);
+        localStorage.removeItem(CAMPAIGN_REF_KEY);
+        localStorage.removeItem(CAMPAIGN_CODE_KEY);
+
         const message = response.verifiedStudent
           ? 'Registration successful! You are verified as a Curtin student.'
           : 'Registration successful! Verify your student email from your account to show the verified badge on reviews.';
@@ -49,6 +87,32 @@ export class RegisterComponent implements OnInit {
       error: (err) => {
         this.isLoading.set(false);
         this.errorMessage.set(err.error?.error || 'Registration failed. Please try again.');
+      }
+    });
+  }
+
+  onPromoCodeChange() {
+    if (this.ref || this.promoCode) {
+      this.validateCampaign(this.ref, this.promoCode);
+    } else {
+      this.campaignMessage.set(null);
+    }
+  }
+
+  private validateCampaign(ref: string, code: string) {
+    if (!ref && !code) {
+      return;
+    }
+
+    this.campaignService.validate(ref || undefined, code || undefined).subscribe({
+      next: (result) => {
+        if (result.valid) {
+          const prize = result.prizeDescription ? ` Prize: ${result.prizeDescription}.` : '';
+          this.campaignMessage.set(`You're signing up for ${result.campaignName}.${prize}`);
+          this.errorMessage.set(null);
+        } else {
+          this.campaignMessage.set(null);
+        }
       }
     });
   }

--- a/frontend/src/app/components/unit-detail/unit-detail.component.html
+++ b/frontend/src/app/components/unit-detail/unit-detail.component.html
@@ -152,25 +152,31 @@
         <h3 class="section-heading">Student Reviews</h3>
         
         <!-- Button to show the add review form -->
-        <button *ngIf="authService.isLoggedIn() && !showAddReviewForm()" 
-                (click)="toggleAddReviewForm()" 
+        <button *ngIf="authService.isLoggedIn() && !showAddReviewForm()"
+                (click)="toggleAddReviewForm()"
                 class="btn btn-primary add-review-btn">
           Add Review
         </button>
       </div>
 
       <!-- The Add Review Form (hidden by default) -->
-      <app-add-review 
-        *ngIf="showAddReviewForm()" 
-        [unitCode]="unit.code" 
+      <app-add-review
+        *ngIf="showAddReviewForm()"
+        [unitCode]="unit.code"
         (reviewAdded)="onReviewAdded()"
+        (reviewError)="onReviewError($event)"
         (cancel)="toggleAddReviewForm()">
       </app-add-review>
+
+      <div *ngIf="duplicateReviewMessage()" class="error-box">
+        {{ duplicateReviewMessage() }}
+        <a routerLink="/my-reviews">Go to My Reviews</a> to update or delete it.
+      </div>
 
       <div *ngIf="!authService.isLoggedIn()" class="login-to-review">
         <p>Want to share your experience? <a routerLink="/login">Log in</a> to leave a review!</p>
       </div>
-      
+
       <div *ngIf="unit.reviews.length === 0" class="no-reviews">
         No reviews yet. Be the first to write one!
       </div>

--- a/frontend/src/app/components/unit-detail/unit-detail.component.ts
+++ b/frontend/src/app/components/unit-detail/unit-detail.component.ts
@@ -29,9 +29,12 @@ export class UnitDetailComponent implements OnInit {
 
   // This will store all the unit information once it's fetched
   unit$: Observable<UnitDetails> | undefined;
-  
+
   // Track if we should show the add review form
   showAddReviewForm = signal(false);
+
+  // Set when the backend rejects a submission because the user already reviewed this unit
+  duplicateReviewMessage = signal<string | null>(null);
 
   ngOnInit(): void {
     this.loadUnit();
@@ -63,12 +66,20 @@ export class UnitDetailComponent implements OnInit {
   }
 
   toggleAddReviewForm() {
+    this.duplicateReviewMessage.set(null);
     this.showAddReviewForm.update(v => !v);
   }
 
   onReviewAdded() {
     this.showAddReviewForm.set(false);
     this.loadUnit();
+  }
+
+  onReviewError(message: string) {
+    if (message.toLowerCase().includes('already reviewed')) {
+      this.showAddReviewForm.set(false);
+      this.duplicateReviewMessage.set(message);
+    }
   }
 
   getStarArray(rating: number): string[] {

--- a/frontend/src/app/models/unit.model.ts
+++ b/frontend/src/app/models/unit.model.ts
@@ -52,8 +52,13 @@ export interface MyReview {
   unitCode: string;
   unitName: string;
   rating: number;
+  finalGrade?: number | null;
   reviewText: string;
   semesterTaken: string;
+  professor?: string;
+  workload?: number;
+  hasExam?: boolean;
+  wouldTakeAgain?: boolean;
   createdAt: string;
 }
 

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -30,12 +30,21 @@ export interface JwtResponse {
   verifiedStudent: boolean;
 }
 
+export interface CampaignProgress {
+  qualifyingReviews: number;
+  requiredReviews: number;
+  entriesEarned: number;
+  maxEntries: number;
+  requireVerifiedStudent: boolean;
+}
+
 export interface AccountStatus {
   email: string;
   verifiedStudent: boolean;
   campaignName: string | null;
   campaignPrizeDescription: string | null;
   campaignEndsAt: string | null;
+  campaignProgress: CampaignProgress | null;
   campaignEntries: CampaignEntrySummary[];
 }
 

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -11,6 +11,8 @@ export interface LoginRequest {
 export interface RegisterRequest {
   email: string;
   password?: string;
+  ref?: string;
+  promoCode?: string;
 }
 
 export interface VerifyStudentRequest {
@@ -31,6 +33,17 @@ export interface JwtResponse {
 export interface AccountStatus {
   email: string;
   verifiedStudent: boolean;
+  campaignName: string | null;
+  campaignPrizeDescription: string | null;
+  campaignEndsAt: string | null;
+  campaignEntries: CampaignEntrySummary[];
+}
+
+export interface CampaignEntrySummary {
+  entryToken: string;
+  campaignName: string;
+  unitCode: string;
+  createdAt: string;
 }
 
 @Injectable({

--- a/frontend/src/app/services/campaign.service.ts
+++ b/frontend/src/app/services/campaign.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface CampaignValidation {
+  valid: boolean;
+  message: string;
+  campaignName: string | null;
+  prizeDescription: string | null;
+  endsAt: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CampaignService {
+  private http = inject(HttpClient);
+  private apiUrl = `${environment.apiUrl}/campaigns`;
+
+  validate(ref?: string, code?: string): Observable<CampaignValidation> {
+    const params: Record<string, string> = {};
+    if (ref?.trim()) {
+      params['ref'] = ref.trim();
+    }
+    if (code?.trim()) {
+      params['code'] = code.trim();
+    }
+    return this.http.get<CampaignValidation>(`${this.apiUrl}/validate`, { params });
+  }
+}

--- a/frontend/src/app/services/review.service.ts
+++ b/frontend/src/app/services/review.service.ts
@@ -4,10 +4,19 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { MyReview } from '../models/unit.model';
 
+export interface CampaignProgress {
+  qualifyingReviews: number;
+  requiredReviews: number;
+  entriesEarned: number;
+  maxEntries: number;
+  requireVerifiedStudent: boolean;
+}
+
 export interface CreateReviewResponse {
   review: unknown;
   campaignEntryToken: string | null;
   campaignName: string | null;
+  campaignProgress: CampaignProgress | null;
 }
 
 @Injectable({

--- a/frontend/src/app/services/review.service.ts
+++ b/frontend/src/app/services/review.service.ts
@@ -4,6 +4,12 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { MyReview } from '../models/unit.model';
 
+export interface CreateReviewResponse {
+  review: unknown;
+  campaignEntryToken: string | null;
+  campaignName: string | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -15,8 +21,8 @@ export class ReviewService {
     return this.http.get<MyReview[]>(`${this.apiUrl}/me`);
   }
 
-  createReview(review: unknown): Observable<unknown> {
-    return this.http.post(this.apiUrl, review);
+  createReview(review: unknown): Observable<CreateReviewResponse> {
+    return this.http.post<CreateReviewResponse>(this.apiUrl, review);
   }
 
   deleteReview(id: string): Observable<void> {

--- a/plans/campaign-promo-codes-runbook.md
+++ b/plans/campaign-promo-codes-runbook.md
@@ -1,0 +1,78 @@
+# Campaign promo codes runbook — deploy checks (PR #41 replacement)
+
+This runbook covers the manual, prod-side steps required by `feat/campaign-promo-codes-v2`.
+This project has no Flyway/Liquibase — schema changes ship via `ddl-auto: update`, so none of these
+steps run automatically. They must be done by hand against the database before/after deploying.
+
+## 1. Pre-deploy: check for duplicate (user_id, unit_id) reviews
+
+The campaign work adds a unique constraint on `reviews (user_id, unit_id)` (`uk_reviews_user_unit`),
+enforcing one review per user per unit — required so campaign entries can't be farmed by leaving
+several reviews on the same unit. Nothing stopped duplicate reviews before this change, so prod's
+`reviews` table may already contain some. **This has not been checked yet** — the email dedup work in
+`plans/prod-hotfix-runbook.md` covered `app_users`, not `reviews`.
+
+Run this against **dev first, then prod**, before deploying this branch:
+
+```sql
+SELECT user_id, unit_id, COUNT(*) AS review_count
+FROM reviews
+GROUP BY user_id, unit_id
+HAVING COUNT(*) > 1;
+```
+
+If this returns zero rows, skip to step 2.
+
+If it returns rows, Postgres will reject the `ALTER TABLE ... ADD CONSTRAINT` on boot. Depending on
+Hibernate's handling this either fails the boot outright or — worse — logs the error and continues,
+leaving the app running **without** the constraint while looking like a normal successful deploy (see
+step 3). Resolve duplicates by keeping the most recent review per `(user_id, unit_id)` pair and deleting
+the rest:
+
+```sql
+WITH ranked AS (
+    SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id, unit_id ORDER BY created_at DESC) AS rn
+    FROM reviews
+)
+DELETE FROM reviews
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+```
+
+Deleting a review also triggers a unit aggregate recalculation on next read for unaffected units, but
+won't happen automatically for historical deletes run directly in SQL — after running the delete, hit
+`POST /admin/units/recalculate-aggregates` (admin-only) once to refresh `averageRating` etc. for any
+affected units.
+
+Re-run the `SELECT ... HAVING COUNT(*) > 1` query afterward — it should return zero rows.
+
+## 2. Deploy order
+
+1. Run the duplicate-review check (step 1) against dev, then prod.
+2. Merge `feat/campaign-promo-codes-v2` and let the normal GitHub Actions deploy run.
+3. Confirm boot (step 3).
+
+## 3. Post-deploy: confirm the new schema actually applied
+
+`ddl-auto: update` logs-and-continues on a failed DDL statement rather than failing the boot, so a
+silently-skipped constraint or table looks identical to a successful deploy from the outside — the app
+keeps serving traffic, campaigns just silently don't enforce what they're supposed to. Check the boot
+logs for both:
+
+- `campaigns` and `campaign_entries` tables were created (Hibernate logs each `create table` statement
+  it runs at `DEBUG`/`INFO` depending on profile; grep for `create table campaigns` and
+  `create table campaign_entries`).
+- The unique constraint was added: grep for `uk_reviews_user_unit` in the boot log. If step 1 was done
+  correctly this should succeed; if you see a constraint-violation error here instead, duplicates still
+  exist — re-run the step 1 query and dedup again, then restart the app so Hibernate retries the DDL.
+
+If either is missing from the logs with no corresponding error, something silently no-opped — connect to
+the database directly and confirm:
+
+```sql
+SELECT to_regclass('campaigns'), to_regclass('campaign_entries');
+SELECT conname FROM pg_constraint WHERE conname = 'uk_reviews_user_unit';
+```
+
+All three should return non-null / one row. If not, the app is running with campaign features exposed
+in the API but without the backing schema — treat as a failed deploy and investigate before letting
+traffic route to campaign endpoints.


### PR DESCRIPTION
## Summary

Rescues PR #41 (`cursor/campaign-promo-codes-f171`), which was 38 commits behind `dev` and marked
CONFLICTING. Rather than rebase/merge that branch, this is a fresh branch off current `dev` with the two
campaign commits cherry-picked over, reconciled with everything `dev` gained in the meantime, and the
9-issue fix plan (`design/campaign-pr-fix-plan.md`) implemented on top.

- **Referral links** — `/register?ref=<slug>&code=<code>` attributes signups to a campaign
- **Promo codes** — optional code field on registration
- **Draw entry tokens** — unique `CH-XXXXXXXX` tokens when campaign criteria are met
- **Configurable eligibility** — per-campaign rules for verification, review count, and review length
- **One review per unit** — enforced via `uk_reviews_user_unit`, with a duplicate-review error message
  that points the user to My Reviews

## Differences from PR #41

**Reconciled with what `dev` gained since the campaign branch was cut:**
- `POST /reviews` binds `ReviewCreateRequest` (not the raw `Review` entity) and sets `createdAt`
  server-side — the campaign entry-awarding hook is wired onto that DTO path. This also means the
  audit's finding #4 (client-controlled `createdAt` faking a campaign window) doesn't apply here.
- `ReviewService.createReview` still calls `unitAggregateService.recalculateForUnit(...)` — the exact
  conflict `plans/cyber-audit.md` predicted between the campaign branch and the perf work (commit
  9534506). Covered by `ReviewCampaignAggregateTest`.
- Email normalization, the config-driven CORS allowlist, and the banned-user JWT check are all dev's
  versions — nothing from the campaign branch touches those files.
- No hand-built JSON error bodies were reintroduced; everything routes through the existing
  `@ControllerAdvice`.

**Scoped out (see "Not included" below):** the campaign branch's second commit also shipped full review
editing (`PATCH /reviews/{id}`, an edit-mode toggle on the add-review form, a `getMyReviewForUnit`
endpoint). That's out of scope for this task, so it was stripped back out — the "one review per unit"
constraint is still fully enforced, and the recovery path is: the error message on a duplicate review
submission links to My Reviews, where the existing delete button lets a user remove and resubmit
(instances of `existsByUser_IdAndUnit_Id`, `duplicateReviewMessage`, `onReviewError` show the minimal
version that shipped instead).

**Fix-plan issues implemented (commit-by-commit):**

| Commit | Issue | Summary |
|---|---|---|
| `0cdcee0` | #3 | `CampaignEntry.review` FK → `SET_NULL` + `unit` field + `existsByCampaign_IdAndUser_IdAndUnit_Id` gate — closes the delete-and-resubmit re-earn loop |
| `270ad9c` | #4 | `CampaignRepo.findByIdForUpdate` (`PESSIMISTIC_WRITE`) held across the whole redemption via `CampaignService.registerUserWithCampaign`, not just the count |
| `ea15b90` | #5, #9 | `CampaignEntryTokenExhaustedException` → 503 via the global advice; confirms AdminResource never regressed to hand-built JSON |
| `26e6929` | #8, audit #10 | Reusable `RateLimiter`/`RateLimitFilter` (IP-keyed, ~10 req/min), applied to `/campaigns/validate`; identical response for not-found/expired/full |
| `6444792` | #2 | Runbook replacing the Flyway-based plan (project has none) — prod dedup check + post-deploy log verification for `uk_reviews_user_unit` |
| *(inline in the cherry-pick)* | #1 | Satisfied by only cherry-picking the two feature commits, excluding the bundled SEO hotfix `dev` already has |
| *(inline in the cherry-pick)* | #6 | Minimal duplicate-review recovery: friendly error + link to My Reviews, no full edit mode |
| *(inline in the cherry-pick)* | #7 | Campaign attribution (`campaign_ref`/`campaign_code`) uses `localStorage`, cleaned up after registration |

## Deploy

See [`plans/campaign-promo-codes-runbook.md`](plans/campaign-promo-codes-runbook.md) — run the
duplicate-`(user_id, unit_id)`-review check against prod **before** deploying, and confirm
`uk_reviews_user_unit` actually appears in the boot logs after.

## Test plan

- [x] Backend suite green via Testcontainers/real Postgres (`CampaignReEarnTest`,
      `CampaignRedemptionLockTest`, `CampaignValidateTest`, `ReviewCampaignAggregateTest`) — one
      pre-existing, unrelated failure (`ApplicationTests`, needs a local `postgres` role; fails
      identically on a clean `dev` checkout)
- [x] Frontend `ng build` succeeds; Vitest suite passes (one pre-existing failure in `app.spec.ts`,
      also reproduces on `dev`)
- [x] Duplicate-review recovery flow verified via browser preview (error message + "Go to My Reviews"
      link render correctly)
- [x] `docker compose` boot log verification could not be completed in this environment (Docker's local
      storage was corrupted by an unrelated host disk-space issue); substituted with the
      Testcontainers-backed suite, which exercises the same `ddl-auto` path against real Postgres 16 and
      confirms `campaigns`/`campaign_entries`/`uk_reviews_user_unit` all get created and used correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)