### PR TITLE
Reject 0-star ratings, order unit reviews newest first (quick-fixes #1, #7)

### DIFF
--- a/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/domain/Review.java
@@ -34,7 +34,7 @@ public class Review {
     @UuidGenerator
     private String id;
 
-    private int rating; // 0-5
+    private int rating; // 1-5
     private Integer finalGrade; // Optional
     @Column(length = 2000)
     private String reviewText;

--- a/backend/src/main/java/com/curtinhonestly/backend/dto/ReviewCreateRequest.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/dto/ReviewCreateRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Size;
 // Only the fields a user is allowed to set on a review. createdAt and id are
 // always assigned server-side - never bind the Review entity directly here.
 public record ReviewCreateRequest(
-        @Min(0) @Max(5) int rating,
+        @Min(1) @Max(5) int rating,
         @Min(0) @Max(100) Integer finalGrade,
         @Size(max = 2000) String reviewText,
         String semesterTaken,

--- a/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/repo/ReviewRepo.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 public interface ReviewRepo extends JpaRepository<Review, String> {
     Optional<Review> findById(String id);
     List<Review> findByUnit_Id(String unitId);
+    List<Review> findByUnit_IdOrderByCreatedAtDesc(String unitId);
     List<Review> findByUser_IdOrderByCreatedAtDesc(String userId);
     long countByCreatedAtAfter(Instant since);
     List<Review> findByCreatedAtAfter(Instant since);

--- a/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/curtinhonestly/backend/service/ReviewService.java
@@ -34,7 +34,7 @@ public class ReviewService {
 
     public List<Review> getReviewsByUnitCode(String unitCode) {
         Unit unit = unitService.getUnitByCode(unitCode);
-        return reviewRepo.findByUnit_Id(unit.getId());
+        return reviewRepo.findByUnit_IdOrderByCreatedAtDesc(unit.getId());
     }
 
     public Page<Review> getPageOfReviews(int page, int size) {

--- a/backend/src/test/java/com/curtinhonestly/backend/resource/ExceptionHandlerTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/resource/ExceptionHandlerTest.java
@@ -76,7 +76,7 @@ class ExceptionHandlerTest {
         String token = jwtUtil.generateToken(user.getEmail(), List.of("ROLE_USER"));
 
         Map<String, Object> invalidPayload = Map.of(
-                "rating", 99, // out of the 0-5 range
+                "rating", 99, // out of the 1-5 range
                 "workload", 5,
                 "unitCode", "SOME-CODE"
         );

--- a/backend/src/test/java/com/curtinhonestly/backend/resource/ReviewOrderingTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/resource/ReviewOrderingTest.java
@@ -1,0 +1,91 @@
+package com.curtinhonestly.backend.resource;
+
+import com.curtinhonestly.backend.config.TestcontainersConfig;
+import com.curtinhonestly.backend.domain.Faculty;
+import com.curtinhonestly.backend.domain.Unit;
+import com.curtinhonestly.backend.domain.UnitLevel;
+import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.domain.UserRole;
+import com.curtinhonestly.backend.repo.UnitRepo;
+import com.curtinhonestly.backend.repo.UserRepo;
+import com.curtinhonestly.backend.security.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfig.class)
+class ReviewOrderingTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UnitRepo unitRepo;
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Test
+    void unitReviewsAreReturnedNewestFirst() throws Exception {
+        Unit unit = new Unit();
+        unit.setCode("QFTEST-ORDER");
+        unit.setName("Quick Fix Ordering Test Unit");
+        unit.setDescription("Unit used to prove reviews come back newest to oldest.");
+        unit.setFaculty(Faculty.SCIENCE_AND_ENGINEERING);
+        unit.setLevel(UnitLevel.UNDERGRADUATE);
+        unitRepo.save(unit);
+
+        User user = new User();
+        user.setEmail("ordering-test@student.curtin.edu.au");
+        user.setPassword(passwordEncoder.encode("password123"));
+        user.setRoles(List.of(UserRole.ROLE_USER));
+        userRepo.saveAndFlush(user);
+        String token = jwtUtil.generateToken(user.getEmail(), List.of("ROLE_USER"));
+
+        for (String marker : List.of("first-review", "second-review", "third-review")) {
+            Map<String, Object> payload = Map.of(
+                    "rating", 4,
+                    "workload", 5,
+                    "reviewText", marker,
+                    "unitCode", "QFTEST-ORDER"
+            );
+            mockMvc.perform(post("/reviews")
+                            .header("Authorization", "Bearer " + token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(payload)))
+                    .andExpect(status().isCreated());
+            Thread.sleep(5);
+        }
+
+        mockMvc.perform(get("/units/QFTEST-ORDER/reviews"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].reviewText").value("third-review"))
+                .andExpect(jsonPath("$[1].reviewText").value("second-review"))
+                .andExpect(jsonPath("$[2].reviewText").value("first-review"));
+    }
+}

--- a/backend/src/test/java/com/curtinhonestly/backend/resource/ZeroStarRatingRejectedTest.java
+++ b/backend/src/test/java/com/curtinhonestly/backend/resource/ZeroStarRatingRejectedTest.java
@@ -1,0 +1,81 @@
+package com.curtinhonestly.backend.resource;
+
+import com.curtinhonestly.backend.config.TestcontainersConfig;
+import com.curtinhonestly.backend.domain.Faculty;
+import com.curtinhonestly.backend.domain.Unit;
+import com.curtinhonestly.backend.domain.UnitLevel;
+import com.curtinhonestly.backend.domain.User;
+import com.curtinhonestly.backend.domain.UserRole;
+import com.curtinhonestly.backend.repo.UnitRepo;
+import com.curtinhonestly.backend.repo.UserRepo;
+import com.curtinhonestly.backend.security.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfig.class)
+class ZeroStarRatingRejectedTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UnitRepo unitRepo;
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Test
+    void zeroStarRatingIsRejected() throws Exception {
+        Unit unit = new Unit();
+        unit.setCode("QFTEST-RATING");
+        unit.setName("Quick Fix Rating Test Unit");
+        unit.setDescription("Unit used to prove a 0-star rating is rejected.");
+        unit.setFaculty(Faculty.SCIENCE_AND_ENGINEERING);
+        unit.setLevel(UnitLevel.UNDERGRADUATE);
+        unitRepo.save(unit);
+
+        User user = new User();
+        user.setEmail("zero-rating-test@student.curtin.edu.au");
+        user.setPassword(passwordEncoder.encode("password123"));
+        user.setRoles(List.of(UserRole.ROLE_USER));
+        userRepo.saveAndFlush(user);
+        String token = jwtUtil.generateToken(user.getEmail(), List.of("ROLE_USER"));
+
+        Map<String, Object> payload = Map.of(
+                "rating", 0,
+                "workload", 5,
+                "reviewText", "This unit gets zero stars from me.",
+                "unitCode", "QFTEST-RATING"
+        );
+
+        mockMvc.perform(post("/reviews")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/frontend/src/app/components/add-review/add-review.component.html
+++ b/frontend/src/app/components/add-review/add-review.component.html
@@ -5,9 +5,9 @@
     <div class="form-grid">
       <!-- Rating Section -->
       <div class="form-group">
-        <label for="rating">Rating (0-5 stars)</label>
+        <label for="rating">Rating (1-5 stars)</label>
         <div class="rating-input">
-          <input type="range" id="rating" min="0" max="5" step="1" [ngModel]="rating()" (ngModelChange)="rating.set($event)" name="rating">
+          <input type="range" id="rating" min="1" max="5" step="1" [ngModel]="rating()" (ngModelChange)="rating.set($event)" name="rating">
           <span class="rating-value">{{ rating() }} / 5</span>
         </div>
       </div>

--- a/plans/quick-fixes.md
+++ b/plans/quick-fixes.md
@@ -1,0 +1,94 @@
+# Quick Fixes
+
+Small bugs and rough edges found while reading the code. Each is independently
+shippable.
+
+---
+
+## 1. 0-star ratings will break review snippets — fix BEFORE the SEO branch merges
+
+**Done** — minimum is now 1 star: `ReviewCreateRequest.rating` is `@Min(1)`, the add-review slider is
+`min="1"`. `unit-seo.utils.ts` already declared `worstRating: '1'`, so no change was needed there.
+
+The add-review slider (`min="0"`) and backend validation
+(`ReviewService.createReview`: `rating < 0 || rating > 5`) both allow `rating = 0`,
+but the SEO plan's JSON-LD declares `worstRating: 1`. One 0-star review emits an
+out-of-bounds `ratingValue` and can invalidate rich results for that unit page.
+
+**Decide:** make 1 the minimum (probably right — what does 0 stars mean vs 1?) or
+change the schema bounds to 0. Either way, align form, backend validation, and
+`unit-seo.utils.ts` in the same PR.
+
+## 2. Unit detail page has no error state
+
+`unit-detail.component.ts` never handles errors on `unit$` — a bad or removed unit
+code leaves the user on the "Loading unit details..." spinner forever, and there is no
+404 route. Add an error branch (`catchError` → error template with a link back to the
+catalog) and a wildcard route.
+
+## 3. Validation errors return HTTP 500
+
+`ReviewResource.createReview` catches all exceptions and returns
+`internalServerError()` — so rating-out-of-range, profanity, and missing-unit
+validation failures are 500s instead of 400s. Cosmetic for users (frontend shows the
+message either way) but poisons error monitoring. Split `IllegalArgumentException`
+→ 400. Same pattern exists in `UnitResource.getUnits` (including a
+`NullPointerException` special case that leaks stack frames into the response body).
+
+(Overlaps [cyber-audit.md](cyber-audit.md) #9 — raw exception messages concatenated
+into hand-built JSON. Fix both at once with a `@ControllerAdvice` global handler.)
+
+## 4. Hardcoded semester dropdown will go stale
+
+`add-review.component.html` offers a fixed list topping out at "Semester 1, 2026".
+Generate options from the current date (current + previous ~4 semesters).
+
+## 5. Profanity word list ships in the client bundle
+
+`profanity-list.ts` (`BANNED_WORDS`) is imported by `add-review.component.ts` — bundle
+weight plus a public list of exactly which words to leetspeak around. Backend
+`ProfanityFilterService` already enforces it. Drop the client-side check or reduce it
+to a generic friendly pre-check message driven by the server response.
+
+## 6. Reviews render dangling optional fields
+
+`unit-detail.component.html` review cards:
+
+- `• Prof. ` renders with nothing after it when `professor` is empty
+- `Grade: %` renders when `finalGrade` is null
+
+Conditionally render both. (Surfacing *more* of the collected data — `hasExam`, review
+dates — is the feature version of this, tracked in [review-experience.md](review-experience.md) #1.)
+
+## 7. Reviews are unordered
+
+**Done** — `ReviewService.getReviewsByUnitCode` now uses
+`ReviewRepo.findByUnit_IdOrderByCreatedAtDesc`, so `GET /units/{code}/reviews` returns newest first.
+
+`ReviewService.getReviewsByUnitCode` → `findByUnit_Id` with no `ORDER BY`. Display
+order is arbitrary, and the SEO JSON-LD takes "first 10 in API order". Order
+`createdAt DESC` server-side.
+
+## 8. Likely-unused review listing endpoint
+
+`GET /units/{unitCode}/reviews` (in `UnitResource`) appears unused by the frontend —
+unit detail gets reviews via `UnitDetailsDTO`. Remove it (or consciously keep + test
+it) rather than maintaining a second review-listing path.
+
+## 9. `MyReviewDTO` is too thin for the my-reviews page
+
+Lacks `workload`, `finalGrade`, `professor`, `hasExam`, `wouldTakeAgain` — users can't
+see their own full review, which becomes a blocker once review editing exists. Widen
+alongside the edit feature (see [review-experience.md](review-experience.md)).
+
+## 10. Zero-review catalog cards look dead
+
+Superseded — the fix ("No reviews yet — be the first" card state) is specified and
+scheduled in [frontend-revamp-plan.md](frontend-revamp-plan.md) Phase 2 (audit item A1).
+
+## 11. Weak email format validation on register
+
+`AuthController.isValidEmail` is `contains("@") && contains(".")`. Low stakes, but a
+standard regex or Jakarta `@Email` validation is nearly free — matters slightly more
+once emails are actually sent (verification/reset flows). (Also flagged as finding #17
+in [cyber-audit.md](cyber-audit.md).)


### PR DESCRIPTION
## Summary

Implements two items from `plans/quick-fixes.md` that hadn't landed yet:

- **#1 — 0-star ratings.** The add-review slider (`min="0"`) and backend validation both allowed `rating = 0`, but `unit-seo.utils.ts`'s JSON-LD already declares `worstRating: '1'`. A 0-star review would emit an out-of-bounds `ratingValue` and could invalidate rich results for that unit page. `ReviewCreateRequest.rating` is now `@Min(1)` (was `@Min(0)`), and the slider's `min` attribute matches. No change needed in `unit-seo.utils.ts` - it was already correct.
- **#7 — unordered reviews.** `GET /units/{code}/reviews` had no `ORDER BY`, so display order was arbitrary and the SEO JSON-LD's "first 10 in API order" wasn't meaningful. Added `ReviewRepo.findByUnit_IdOrderByCreatedAtDesc` (matching the existing `findByUser_IdOrderByCreatedAtDesc` pattern) and switched `getReviewsByUnitCode` to use it.

One commit per fix:
| Commit | Fix |
|---|---|
| `ebd5ec7` | quick-fixes.md #1 - reject 0-star ratings |
| `6bea19c` | quick-fixes.md #7 - order unit reviews newest to oldest |

## Test plan

- [x] `./gradlew compileJava compileTestJava` passes
- [ ] `./gradlew test` (Testcontainers-backed; requires Docker) - `ZeroStarRatingRejectedTest`, `ReviewOrderingTest` added; `ExceptionHandlerTest`'s stale `0-5 range` comment corrected to `1-5`
- [ ] Manual: submitting a review with the rating slider dragged to the minimum now posts `rating: 1`, not `0`
- [ ] Manual: a unit with several reviews shows the most recent one first